### PR TITLE
Implement QASM 3 formatter with comment extraction and timing expressions support

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,249 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatQASM(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "version and include statements",
+			input: `OPENQASM 3.0;
+include"stdgates.qasm";`,
+			expected: `OPENQASM 3.0;
+include "stdgates.qasm";
+`,
+		},
+		{
+			name: "indentation in blocks",
+			input: `OPENQASM 3.0;
+gate h q {
+x q;
+}`,
+			expected: `OPENQASM 3.0;
+
+gate h q {
+  x q;
+}
+`,
+		},
+		{
+			name: "spacing around binary operators",
+			input: `bit[2]c=0;
+int[32] x=5+3*2;`,
+			expected: `bit[2] c = 0;
+int[32] x = 5 + 3 * 2;
+`,
+		},
+		{
+			name: "no spaces in brackets",
+			input: `qubit[ 2 ] q;
+h q[ 0 ];`,
+			expected: `qubit[2] q;
+h q[0];
+`,
+		},
+		{
+			name: "comments preservation",
+			input: `// This is a header comment
+OPENQASM 3.0;
+// Include standard gates
+include "stdgates.qasm"; // Standard gates
+/* Multi-line
+   comment */
+qubit[2] q;  // Qubit declaration`,
+			expected: `// This is a header comment
+OPENQASM 3.0;
+// Include standard gates
+include "stdgates.qasm"; // Standard gates
+
+/* Multi-line
+   comment */
+qubit[2] q; // Qubit declaration
+`,
+		},
+		{
+			name: "timing expressions",
+			input: `delay[100ns] q;
+delay[  50  ns  ] q;`,
+			expected: `delay[100ns] q;
+delay[50ns] q;
+`,
+		},
+		{
+			name: "empty lines between major blocks",
+			input: `OPENQASM 3.0;
+include "stdgates.qasm";
+qubit[2] q;
+bit c;
+gate custom a, b {
+  cx a, b;
+}
+h q[0];
+measure q[0] -> c;`,
+			expected: `OPENQASM 3.0;
+include "stdgates.qasm";
+
+qubit[2] q;
+bit c;
+
+gate custom a, b {
+  cx a, b;
+}
+
+h q[0];
+measure q[0] -> c;
+`,
+		},
+		{
+			name: "if statement formatting",
+			input: `if(c==1){
+h q;
+}else{
+x q;
+}`,
+			expected: `if (c == 1) {
+  h q;
+} else {
+  x q;
+}
+`,
+		},
+		{
+			name: "gate call with parameters",
+			input: `rz(pi/2)q[0];
+cphase(pi/4)q[0],q[1];`,
+			expected: `rz(pi/2) q[0];
+cphase(pi/4) q[0], q[1];
+`,
+		},
+		{
+			name: "measurement formatting",
+			input: `measureq[0]->c[0];
+measure q->c;`,
+			expected: `measure q[0] -> c[0];
+measure q -> c;
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted, err := FormatQASM(tt.input)
+			if err != nil {
+				t.Errorf("FormatQASM() error = %v", err)
+				return
+			}
+
+			// Compare line by line for better error messages
+			expectedLines := strings.Split(tt.expected, "\n")
+			actualLines := strings.Split(formatted, "\n")
+
+			// Check if number of lines match
+			if len(expectedLines) != len(actualLines) {
+				t.Errorf("Line count mismatch:\nexpected %d lines:\n%s\ngot %d lines:\n%s",
+					len(expectedLines), tt.expected, len(actualLines), formatted)
+				return
+			}
+
+			// Compare each line
+			for i := range expectedLines {
+				if expectedLines[i] != actualLines[i] {
+					t.Errorf("Line %d mismatch:\nexpected: %q\ngot: %q",
+						i+1, expectedLines[i], actualLines[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFormatQASMWithConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		config   *Config
+		expected string
+	}{
+		{
+			name: "custom indent size",
+			input: `gate h q {
+x q;
+}`,
+			config: &Config{
+				Indent:  4,
+				Newline: true,
+			},
+			expected: `gate h q {
+    x q;
+}
+`,
+		},
+		{
+			name: "no trailing newline",
+			input: `OPENQASM 3.0;
+include "stdgates.qasm";`,
+			config: &Config{
+				Indent:  2,
+				Newline: false,
+			},
+			expected: `OPENQASM 3.0;
+include "stdgates.qasm";`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted, err := FormatQASMWithConfig(tt.input, tt.config)
+			if err != nil {
+				t.Errorf("FormatQASMWithConfig() error = %v", err)
+				return
+			}
+
+			if formatted != tt.expected {
+				t.Errorf("FormatQASMWithConfig() = %v, want %v", formatted, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateQASM(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name: "valid QASM",
+			input: `OPENQASM 3.0;
+include "stdgates.qasm";
+qubit[2] q;
+h q[0];`,
+			wantErr: false,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name: "invalid syntax",
+			input: `OPENQASM 3.0;
+invalid command;`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateQASM(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateQASM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -349,6 +349,29 @@ func (p *ParenthesizedExpression) String() string {
 	return "ParenthesizedExpression"
 }
 
+// TimingExpression represents timing expressions like 100ns
+type TimingExpression struct {
+	BaseNode
+	Value Expression `json:"value"`
+	Unit  string     `json:"unit"` // "ns", "us", "ms", etc.
+}
+
+func (t *TimingExpression) ExpressionNode() {}
+func (t *TimingExpression) String() string {
+	return "TimingExpression"
+}
+
+// DelayExpression represents delay expressions like delay[100ns]
+type DelayExpression struct {
+	BaseNode
+	Timing Expression `json:"timing"`
+}
+
+func (d *DelayExpression) ExpressionNode() {}
+func (d *DelayExpression) String() string {
+	return "DelayExpression"
+}
+
 // TypeInfo represents type information for AST nodes
 type TypeInfo struct {
 	Kind        string   `json:"kind"`                  // "qubit", "bit", "int", "float", "bool"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -39,6 +39,7 @@ func DefaultParseOptions() *ParseOptions {
 // Parser represents the main OpenQASM 3.0 parser
 type Parser struct {
 	options *ParseOptions
+	stream  antlr.TokenStream
 }
 
 // NewParser creates a new parser with default options
@@ -56,6 +57,11 @@ func NewParserWithOptions(opts *ParseOptions) *Parser {
 	return &Parser{
 		options: opts,
 	}
+}
+
+// GetTokenStream returns the current token stream
+func (p *Parser) GetTokenStream() antlr.TokenStream {
+	return p.stream
 }
 
 // ParseString parses QASM code from a string
@@ -126,6 +132,7 @@ func (p *Parser) ParseWithErrors(content string) *ParseResult {
 
 	// Create token stream
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	p.stream = stream
 
 	// Create parser (this will be replaced with generated code)
 	parser := p.createParser(stream)
@@ -165,10 +172,12 @@ func (p *Parser) ParseWithErrors(content string) *ParseResult {
 		allErrors = allErrors[:p.options.MaxErrors]
 	}
 
-	return &ParseResult{
+	result := &ParseResult{
 		Program: program,
 		Errors:  allErrors,
 	}
+
+	return result
 }
 
 // preprocessContent handles common formatting issues

--- a/spec/formatter.yaml
+++ b/spec/formatter.yaml
@@ -1,0 +1,54 @@
+# OpenQASM 3 Formatter Specification
+
+language: OpenQASM 3.0
+style_reference: https://github.com/openqasm/openqasm/tree/main/examples
+
+formatting_rules:
+  version_declaration:
+    - Place 'OPENQASM 3.0;' at the very top.
+    - Follow immediately with include statements (one per line).
+
+  indentation:
+    - Use 2 spaces per indent level.
+
+  spacing:
+    - Add spaces around binary operators (=, +, -, *, /, ^, etc.).
+    - No spaces inside brackets [], parentheses (), or braces {}.
+    - Function or gate call parameters have no space between function name and parentheses.
+
+  statements:
+    - Terminate all statements with a semicolon.
+    - One statement per line.
+    - Do not combine multiple statements on one line.
+
+  blocks:
+    - Opening brace { stays on the same line.
+    - Closing brace } goes on a new line with matching indentation.
+    - Body content inside blocks is indented.
+
+  declarations:
+    - Each declaration should be on its own line.
+    - Place array size (e.g., qubit[3]) immediately after type with no space.
+
+  control_flow:
+    - Add space after keywords like `if`, `while`, `for`, `switch`.
+    - Wrap conditions in parentheses.
+    - Each control-flow block follows standard indentation and bracing rules.
+
+  delay_and_timing:
+    - Timing unit expressions like `100ns` are written compactly.
+    - Use square brackets tightly in e.g. `delay[100ns]`.
+
+  comments:
+    - Preserve all comments.
+    - Inline comments use `//` with one space before.
+    - Multiline comments `/* */` are preserved as-is.
+
+  whitespace:
+    - Insert one empty line between major blocks (functions, gates, for-loops).
+    - Do not insert empty lines between variable declarations unless grouping is intentional.
+
+  file_end:
+    - Ensure the file ends with a newline character.
+
+examples_source: examples/*.qasm from official OpenQASM repository


### PR DESCRIPTION
Introduce a formatter for OpenQASM 3.0 that includes rules for formatting, comment extraction, and support for timing expressions. Comprehensive test cases validate the functionality and adherence to formatting specifications.