### PR TITLE
Add QASM test cases and enhance highlighter support

### DIFF
--- a/highlight/highlight.go
+++ b/highlight/highlight.go
@@ -1,0 +1,393 @@
+package highlight
+
+import (
+	"strings"
+
+	"github.com/antlr4-go/antlr/v4"
+	qasm_gen "github.com/orangekame3/qasmtools/parser/gen"
+)
+
+// Color represents ANSI color codes for terminal output
+type Color string
+
+const (
+	Reset   Color = "\033[0m"
+	Red     Color = "\033[31m"
+	Green   Color = "\033[32m"
+	Yellow  Color = "\033[33m"
+	Blue    Color = "\033[34m"
+	Magenta Color = "\033[35m"
+	Cyan    Color = "\033[36m"
+	White   Color = "\033[37m"
+	Bold    Color = "\033[1m"
+)
+
+// TokenInfo represents detailed information about a token
+type TokenInfo struct {
+	Type     TokenType `json:"type"`
+	TypeName string    `json:"type_name"`
+	Content  string    `json:"content"`
+	Line     int       `json:"line"`
+	Column   int       `json:"column"`
+	Length   int       `json:"length"`
+}
+
+// HighlightResult represents the result of syntax highlighting
+type HighlightResult struct {
+	Tokens []TokenInfo `json:"tokens"`
+}
+
+// ColorScheme defines the colors for different token types
+type ColorScheme struct {
+	Keyword          Color
+	Operator         Color
+	Identifier       Color
+	Number           Color
+	String           Color
+	Comment          Color
+	Gate             Color
+	Measurement      Color
+	Register         Color
+	Punctuation      Color
+	BuiltinGate      Color
+	BuiltinQuantum   Color
+	BuiltinClassical Color
+	BuiltinConstant  Color
+	AccessControl    Color
+	Extern           Color
+	HardwareQubit    Color
+}
+
+// DefaultColorScheme returns the default color scheme
+func DefaultColorScheme() *ColorScheme {
+	return &ColorScheme{
+		Keyword:          Yellow,
+		Operator:         Red,
+		Identifier:       White,
+		Number:           Cyan,
+		String:           Green,
+		Comment:          Blue,
+		Gate:            Magenta,
+		Measurement:      Red,
+		Register:         Yellow,
+		Punctuation:      White,
+		BuiltinGate:      Magenta,
+		BuiltinQuantum:   Red,
+		BuiltinClassical: Green,
+		BuiltinConstant:  Cyan,
+		AccessControl:    Yellow,
+		Extern:          Blue,
+		HardwareQubit:    Magenta,
+	}
+}
+
+// TokenType represents the type of syntax token
+type TokenType int
+
+const (
+	// Token types for syntax highlighting
+	TokenKeyword TokenType = iota
+	TokenOperator
+	TokenIdentifier
+	TokenNumber
+	TokenString
+	TokenComment
+	TokenGate
+	TokenMeasurement
+	TokenRegister
+	TokenPunctuation
+	TokenBuiltinGate
+	TokenBuiltinQuantum
+	TokenBuiltinClassical
+	TokenBuiltinConstant
+	TokenAccessControl
+	TokenExtern
+	TokenHardwareQubit
+)
+
+// Token represents a syntax highlighted token
+type Token struct {
+	Type    TokenType
+	Content string
+	Line    int
+	Column  int
+}
+
+// Highlighter provides syntax highlighting for QASM code
+type Highlighter struct {
+	tokens      []TokenInfo
+	colorScheme *ColorScheme
+}
+
+// New creates a new Highlighter instance with default color scheme
+func New() *Highlighter {
+	return &Highlighter{
+		colorScheme: DefaultColorScheme(),
+	}
+}
+
+// NewWithColorScheme creates a new Highlighter instance with custom color scheme
+func NewWithColorScheme(scheme *ColorScheme) *Highlighter {
+	return &Highlighter{
+		colorScheme: scheme,
+	}
+}
+
+// Highlight performs syntax highlighting on the given QASM code and returns colored output
+func (h *Highlighter) Highlight(input string) (string, error) {
+	// Create the input stream
+	inputStream := antlr.NewInputStream(input)
+
+	// Create the lexer
+	lexer := qasm_gen.Newqasm3Lexer(inputStream)
+	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+
+	// Clear previous tokens
+	h.tokens = make([]TokenInfo, 0)
+
+	// Walk through all tokens
+	for {
+		t := stream.LT(1)
+		if t.GetTokenType() == antlr.TokenEOF {
+			break
+		}
+		h.processToken(t)
+		stream.Consume()
+	}
+
+	return h.ColoredString(), nil
+}
+
+// processToken converts an ANTLR token to a syntax highlighting token
+func (h *Highlighter) processToken(t antlr.Token) {
+	tokenType := h.getTokenType(t)
+	token := TokenInfo{
+		Type:     tokenType,
+		TypeName: h.tokenTypeToString(tokenType),
+		Content:  t.GetText(),
+		Line:     t.GetLine(),
+		Column:   t.GetColumn(),
+		Length:   len(t.GetText()),
+	}
+	h.tokens = append(h.tokens, token)
+}
+
+// GetTokens returns the tokens for LSP integration
+func (h *Highlighter) GetTokens() []TokenInfo {
+	return h.tokens
+}
+
+// ColoredString returns the colored string representation of the tokens
+func (h *Highlighter) ColoredString() string {
+	var result strings.Builder
+	currentLine := 1
+	currentColumn := 0
+
+	for _, token := range h.tokens {
+		// Add newlines if needed
+		for currentLine < token.Line {
+			result.WriteString("\n")
+			currentLine++
+			currentColumn = 0
+		}
+
+		// Add spaces for correct column position
+		for currentColumn < token.Column {
+			result.WriteString(" ")
+			currentColumn++
+		}
+
+		// Get color for token type
+		color := h.getColorForToken(token.Type)
+
+		// Write colored token
+		result.WriteString(string(color))
+		result.WriteString(token.Content)
+		result.WriteString(string(Reset))
+
+		currentColumn += token.Length
+	}
+
+	return result.String()
+}
+
+// getColorForToken returns the appropriate color for a token type
+func (h *Highlighter) getColorForToken(t TokenType) Color {
+	switch t {
+	case TokenKeyword:
+		return h.colorScheme.Keyword
+	case TokenOperator:
+		return h.colorScheme.Operator
+	case TokenIdentifier:
+		return h.colorScheme.Identifier
+	case TokenNumber:
+		return h.colorScheme.Number
+	case TokenString:
+		return h.colorScheme.String
+	case TokenComment:
+		return h.colorScheme.Comment
+	case TokenGate:
+		return h.colorScheme.Gate
+	case TokenMeasurement:
+		return h.colorScheme.Measurement
+	case TokenRegister:
+		return h.colorScheme.Register
+	case TokenPunctuation:
+		return h.colorScheme.Punctuation
+	case TokenBuiltinGate:
+		return h.colorScheme.BuiltinGate
+	case TokenBuiltinQuantum:
+		return h.colorScheme.BuiltinQuantum
+	case TokenBuiltinClassical:
+		return h.colorScheme.BuiltinClassical
+	case TokenBuiltinConstant:
+		return h.colorScheme.BuiltinConstant
+	case TokenAccessControl:
+		return h.colorScheme.AccessControl
+	case TokenExtern:
+		return h.colorScheme.Extern
+	case TokenHardwareQubit:
+		return h.colorScheme.HardwareQubit
+	default:
+		return Reset
+	}
+}
+
+// getTokenType determines the token type for syntax highlighting
+func (h *Highlighter) getTokenType(t antlr.Token) TokenType {
+	switch t.GetTokenType() {
+	// Keywords
+	case 1, 2, // OPENQASM, INCLUDE
+		4, 5, 6, // DEF, CAL, DEFCAL
+		10, 11, // LET, BREAK
+		12, 13, 14, // CONTINUE, IF, ELSE
+		15, 16, 17, // END, RETURN, FOR
+		18, 19: // WHILE, IN
+		return TokenKeyword
+
+	// Types and registers
+	case 31, 32, 33, // QREG, QUBIT, CREG
+		34, 35: // BOOL, BIT
+		return TokenRegister
+
+	// Builtin gates and quantum operations
+	case 53: // RESET
+		return TokenBuiltinQuantum
+
+	// Operators
+	case 69, 71, 72, // PLUS, MINUS, ASTERISK
+		74, 67, 68, // SLASH, EQUALS, ARROW
+		84, 86, // EqualityOperator, ComparisonOperator
+		63: // COLON
+		return TokenOperator
+
+	// Gates and extern
+	case 7: // GATE token
+		return TokenGate
+	case 8: // EXTERN
+		return TokenExtern
+
+	// Measurements
+	case 54: // MEASURE
+		return TokenMeasurement
+
+	// Numbers
+	case 92, 93, 96: // DecimalIntegerLiteral, HexIntegerLiteral, FloatLiteral
+		return TokenNumber
+
+	// Strings
+	case 106: // StringLiteral
+		return TokenString
+
+	// Comments
+	case 101, 102: // LineComment, BlockComment
+		return TokenComment
+
+	// Access control
+	case 28, 29, 30: // CONST, READONLY, MUTABLE
+		return TokenAccessControl
+
+	// Builtin constants
+	case 88: // IMAG
+		return TokenBuiltinConstant
+
+	// Builtin classical functions
+	case 42: // VOID
+		return TokenBuiltinClassical
+
+	// Hardware qubits (special identifiers starting with $)
+	case 95: // HardwareQubit
+		return TokenHardwareQubit
+
+	// Regular identifiers
+	case 94: // Identifier
+		// Check if it's a builtin gate (U, CX)
+		content := t.GetText()
+		if content == "U" || content == "CX" {
+			return TokenBuiltinGate
+		}
+		// Check if it's a builtin classical function
+		if content == "sin" || content == "cos" || content == "tan" ||
+			content == "exp" || content == "ln" || content == "sqrt" {
+			return TokenBuiltinClassical
+		}
+		// Check if it's a builtin constant
+		if content == "pi" || content == "tau" || content == "euler" {
+			return TokenBuiltinConstant
+		}
+		return TokenIdentifier
+
+	// Punctuation
+	case 64, 66, // SEMICOLON, COMMA
+		61, 62, // LPAREN, RPAREN
+		57, 58, // LBRACKET, RBRACKET
+		59, 60, // LBRACE, RBRACE
+		83: // EXCLAMATION_POINT
+		return TokenPunctuation
+
+	default:
+		return TokenIdentifier
+	}
+}
+
+// tokenTypeToString converts a TokenType to its string representation
+func (h *Highlighter) tokenTypeToString(t TokenType) string {
+	switch t {
+	case TokenKeyword:
+		return "keyword"
+	case TokenOperator:
+		return "operator"
+	case TokenIdentifier:
+		return "identifier"
+	case TokenNumber:
+		return "number"
+	case TokenString:
+		return "string"
+	case TokenComment:
+		return "comment"
+	case TokenGate:
+		return "gate"
+	case TokenMeasurement:
+		return "measurement"
+	case TokenRegister:
+		return "register"
+	case TokenPunctuation:
+		return "punctuation"
+	case TokenBuiltinGate:
+		return "builtin_gate"
+	case TokenBuiltinQuantum:
+		return "builtin_quantum"
+	case TokenBuiltinClassical:
+		return "builtin_classical"
+	case TokenBuiltinConstant:
+		return "builtin_constant"
+	case TokenAccessControl:
+		return "access_control"
+	case TokenExtern:
+		return "extern"
+	case TokenHardwareQubit:
+		return "hardware_qubit"
+	default:
+		return "unknown"
+	}
+}

--- a/highlight/highlight_test.go
+++ b/highlight/highlight_test.go
@@ -1,0 +1,139 @@
+package highlight
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHighlighter_ColoredOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "basic keywords and operators",
+			input: `OPENQASM 3.0;
+include "stdgates.inc";
+gate h q { }`,
+		},
+		{
+			name: "measurements and comments",
+			input: `// This is a comment
+measure q -> c; // Measurement`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New()
+			output, err := h.Highlight(tt.input)
+			if err != nil {
+				t.Errorf("Highlight() error = %v", err)
+				return
+			}
+
+			// Verify that the output contains ANSI color codes
+			if !strings.Contains(output, "\033[") {
+				t.Error("Output does not contain ANSI color codes")
+			}
+
+			// Verify that each line ends with reset code
+			lines := strings.Split(output, "\n")
+			for _, line := range lines {
+				if line != "" && !strings.HasSuffix(line, string(Reset)) {
+					t.Errorf("Line does not end with reset code: %q", line)
+				}
+			}
+		})
+	}
+}
+
+func TestHighlighter_TokenInfo(t *testing.T) {
+	input := `OPENQASM 3.0;
+include "stdgates.inc";
+
+// Initialize qubits
+qubit[2] q;
+bit[2] c;
+
+// Apply gates
+h q[0];
+cx q[0], q[1];
+
+// Measure
+measure q -> c;`
+
+	h := New()
+	_, err := h.Highlight(input)
+	if err != nil {
+		t.Errorf("Highlight() error = %v", err)
+		return
+	}
+
+	tokens := h.GetTokens()
+	if len(tokens) == 0 {
+		t.Error("GetTokens() returned no tokens")
+		return
+	}
+
+	// Check specific token positions
+	expectedChecks := []struct {
+		pos      int
+		wantType string
+		content  string
+	}{
+		{0, "keyword", "OPENQASM"},
+		{1, "number", "3.0"},
+		{2, "punctuation", ";"},
+		{3, "keyword", "include"},
+		{4, "string", "\"stdgates.inc\""},
+	}
+
+	for _, check := range expectedChecks {
+		if check.pos >= len(tokens) {
+			t.Errorf("Token position %d out of range (got %d tokens)", check.pos, len(tokens))
+			continue
+		}
+
+		token := tokens[check.pos]
+		if token.TypeName != check.wantType {
+			t.Errorf("Token[%d] type = %v, want %v", check.pos, token.TypeName, check.wantType)
+		}
+		if token.Content != check.content {
+			t.Errorf("Token[%d] content = %v, want %v", check.pos, token.Content, check.content)
+		}
+	}
+}
+
+func TestHighlighter_CustomColorScheme(t *testing.T) {
+	scheme := &ColorScheme{
+		Keyword:     Blue,
+		Operator:    Green,
+		Identifier:  Yellow,
+		Number:      Red,
+		String:      Magenta,
+		Comment:     Cyan,
+		Gate:        Red,
+		Measurement: Blue,
+		Register:    Green,
+		Punctuation: White,
+	}
+
+	h := NewWithColorScheme(scheme)
+	input := `OPENQASM 3.0;
+// Test comment
+measure q -> c;`
+
+	output, err := h.Highlight(input)
+	if err != nil {
+		t.Errorf("Highlight() error = %v", err)
+		return
+	}
+
+	// Verify that the output contains the custom colors
+	if !strings.Contains(output, string(Blue)) ||
+		!strings.Contains(output, string(Cyan)) ||
+		!strings.Contains(output, string(Yellow)) {
+		t.Error("Output does not contain expected custom colors")
+	}
+}

--- a/testdata/highlighter/expected/basic.json
+++ b/testdata/highlighter/expected/basic.json
@@ -1,0 +1,142 @@
+{
+	"tokens": [
+		{
+			"type": "keyword",
+			"content": "OPENQASM",
+			"line": 1,
+			"column": 0
+		},
+		{
+			"type": "number",
+			"content": "3.0",
+			"line": 1,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 1,
+			"column": 12
+		},
+		{
+			"type": "keyword",
+			"content": "include",
+			"line": 2,
+			"column": 0
+		},
+		{
+			"type": "string",
+			"content": "\"stdgates.inc\"",
+			"line": 2,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 2,
+			"column": 21
+		},
+		{
+			"type": "comment",
+			"content": "// This is a comment",
+			"line": 4,
+			"column": 0
+		},
+		{
+			"type": "gate",
+			"content": "gate",
+			"line": 5,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 5,
+			"column": 5
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 5,
+			"column": 7
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 5,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 5,
+			"column": 11
+		},
+		{
+			"type": "identifier",
+			"content": "qubit",
+			"line": 7,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 7,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 7,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 8,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 8,
+			"column": 2
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 8,
+			"column": 3
+		},
+		{
+			"type": "measurement",
+			"content": "measure",
+			"line": 9,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 9,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "->",
+			"line": 9,
+			"column": 10
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 9,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 9,
+			"column": 14
+		}
+	]
+}

--- a/testdata/highlighter/expected/builtins.json
+++ b/testdata/highlighter/expected/builtins.json
@@ -1,0 +1,736 @@
+{
+	"tokens": [
+		{
+			"type": "keyword",
+			"content": "OPENQASM",
+			"line": 1,
+			"column": 0
+		},
+		{
+			"type": "number",
+			"content": "3.0",
+			"line": 1,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 1,
+			"column": 12
+		},
+		{
+			"type": "comment",
+			"content": "// Builtin gates",
+			"line": 3,
+			"column": 0
+		},
+		{
+			"type": "builtin_gate",
+			"content": "U",
+			"line": 4,
+			"column": 0
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 4,
+			"column": 1
+		},
+		{
+			"type": "builtin_constant",
+			"content": "pi",
+			"line": 4,
+			"column": 2
+		},
+		{
+			"type": "operator",
+			"content": "/",
+			"line": 4,
+			"column": 4
+		},
+		{
+			"type": "number",
+			"content": "2",
+			"line": 4,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 4,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 4,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 4,
+			"column": 9
+		},
+		{
+			"type": "builtin_constant",
+			"content": "pi",
+			"line": 4,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 4,
+			"column": 13
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 4,
+			"column": 15
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 4,
+			"column": 16
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 4,
+			"column": 17
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 4,
+			"column": 18
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 4,
+			"column": 19
+		},
+		{
+			"type": "builtin_gate",
+			"content": "CX",
+			"line": 5,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 5,
+			"column": 3
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 5,
+			"column": 4
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 5,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 5,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 5,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 5,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 5,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 5,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 5,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 5,
+			"column": 13
+		},
+		{
+			"type": "comment",
+			"content": "// Builtin quantum operations",
+			"line": 7,
+			"column": 0
+		},
+		{
+			"type": "builtin_quantum",
+			"content": "reset",
+			"line": 8,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 8,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 8,
+			"column": 7
+		},
+		{
+			"type": "builtin_quantum",
+			"content": "barrier",
+			"line": 9,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 9,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 9,
+			"column": 9
+		},
+		{
+			"type": "measurement",
+			"content": "measure",
+			"line": 10,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 10,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "->",
+			"line": 10,
+			"column": 10
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 10,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 10,
+			"column": 14
+		},
+		{
+			"type": "comment",
+			"content": "// Builtin classical functions",
+			"line": 12,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 13,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "angle",
+			"line": 13,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 13,
+			"column": 10
+		},
+		{
+			"type": "builtin_constant",
+			"content": "pi",
+			"line": 13,
+			"column": 12
+		},
+		{
+			"type": "operator",
+			"content": "/",
+			"line": 13,
+			"column": 14
+		},
+		{
+			"type": "number",
+			"content": "2",
+			"line": 13,
+			"column": 15
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 13,
+			"column": 16
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 14,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 14,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 14,
+			"column": 6
+		},
+		{
+			"type": "builtin_classical",
+			"content": "sin",
+			"line": 14,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 14,
+			"column": 11
+		},
+		{
+			"type": "identifier",
+			"content": "angle",
+			"line": 14,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 14,
+			"column": 17
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 14,
+			"column": 18
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 15,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "y",
+			"line": 15,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 15,
+			"column": 6
+		},
+		{
+			"type": "builtin_classical",
+			"content": "cos",
+			"line": 15,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 15,
+			"column": 11
+		},
+		{
+			"type": "identifier",
+			"content": "angle",
+			"line": 15,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 15,
+			"column": 17
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 15,
+			"column": 18
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 16,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "z",
+			"line": 16,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 16,
+			"column": 6
+		},
+		{
+			"type": "builtin_classical",
+			"content": "sqrt",
+			"line": 16,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 16,
+			"column": 12
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 16,
+			"column": 13
+		},
+		{
+			"type": "operator",
+			"content": "*",
+			"line": 16,
+			"column": 14
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 16,
+			"column": 15
+		},
+		{
+			"type": "operator",
+			"content": "+",
+			"line": 16,
+			"column": 17
+		},
+		{
+			"type": "identifier",
+			"content": "y",
+			"line": 16,
+			"column": 19
+		},
+		{
+			"type": "operator",
+			"content": "*",
+			"line": 16,
+			"column": 20
+		},
+		{
+			"type": "identifier",
+			"content": "y",
+			"line": 16,
+			"column": 21
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 16,
+			"column": 22
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 16,
+			"column": 23
+		},
+		{
+			"type": "comment",
+			"content": "// Builtin constants",
+			"line": 18,
+			"column": 0
+		},
+		{
+			"type": "access_control",
+			"content": "const",
+			"line": 19,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "real_pi",
+			"line": 19,
+			"column": 6
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 19,
+			"column": 14
+		},
+		{
+			"type": "builtin_constant",
+			"content": "pi",
+			"line": 19,
+			"column": 16
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 19,
+			"column": 18
+		},
+		{
+			"type": "access_control",
+			"content": "const",
+			"line": 20,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "real_tau",
+			"line": 20,
+			"column": 6
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 20,
+			"column": 15
+		},
+		{
+			"type": "builtin_constant",
+			"content": "tau",
+			"line": 20,
+			"column": 17
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 20,
+			"column": 20
+		},
+		{
+			"type": "access_control",
+			"content": "const",
+			"line": 21,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "real_euler",
+			"line": 21,
+			"column": 6
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 21,
+			"column": 17
+		},
+		{
+			"type": "builtin_constant",
+			"content": "euler",
+			"line": 21,
+			"column": 19
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 21,
+			"column": 24
+		},
+		{
+			"type": "comment",
+			"content": "// Hardware qubits",
+			"line": 23,
+			"column": 0
+		},
+		{
+			"type": "hardware_qubit",
+			"content": "$0",
+			"line": 24,
+			"column": 0
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 24,
+			"column": 3
+		},
+		{
+			"type": "builtin_gate",
+			"content": "U",
+			"line": 24,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 24,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 24,
+			"column": 7
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 24,
+			"column": 8
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 24,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 24,
+			"column": 11
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 24,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 24,
+			"column": 14
+		},
+		{
+			"type": "hardware_qubit",
+			"content": "$1",
+			"line": 24,
+			"column": 16
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 24,
+			"column": 18
+		},
+		{
+			"type": "comment",
+			"content": "// Access control",
+			"line": 26,
+			"column": 0
+		},
+		{
+			"type": "access_control",
+			"content": "const",
+			"line": 27,
+			"column": 0
+		},
+		{
+			"type": "register",
+			"content": "int",
+			"line": 27,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 27,
+			"column": 10
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 27,
+			"column": 12
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 27,
+			"column": 14
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 27,
+			"column": 15
+		},
+		{
+			"type": "access_control",
+			"content": "mutable",
+			"line": 28,
+			"column": 0
+		},
+		{
+			"type": "register",
+			"content": "float",
+			"line": 28,
+			"column": 8
+		},
+		{
+			"type": "identifier",
+			"content": "y",
+			"line": 28,
+			"column": 14
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 28,
+			"column": 16
+		},
+		{
+			"type": "number",
+			"content": "2.0",
+			"line": 28,
+			"column": 18
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 28,
+			"column": 21
+		}
+	]
+}

--- a/testdata/highlighter/expected/control_flow.json
+++ b/testdata/highlighter/expected/control_flow.json
@@ -1,0 +1,580 @@
+{
+	"tokens": [
+		{
+			"type": "keyword",
+			"content": "OPENQASM",
+			"line": 1,
+			"column": 0
+		},
+		{
+			"type": "number",
+			"content": "3.0",
+			"line": 1,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 1,
+			"column": 12
+		},
+		{
+			"type": "comment",
+			"content": "// For loop",
+			"line": 3,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "for",
+			"line": 4,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 4,
+			"column": 4
+		},
+		{
+			"type": "keyword",
+			"content": "in",
+			"line": 4,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 4,
+			"column": 9
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 4,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": ":",
+			"line": 4,
+			"column": 11
+		},
+		{
+			"type": "number",
+			"content": "3",
+			"line": 4,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 4,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 4,
+			"column": 15
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 5,
+			"column": 4
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 5,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 5,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 5,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 5,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 5,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 6,
+			"column": 0
+		},
+		{
+			"type": "comment",
+			"content": "// While loop",
+			"line": 8,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "while",
+			"line": 9,
+			"column": 0
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 9,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 9,
+			"column": 7
+		},
+		{
+			"type": "operator",
+			"content": ">",
+			"line": 9,
+			"column": 9
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 9,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 9,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 9,
+			"column": 14
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 10,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 10,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 10,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "-",
+			"line": 10,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 10,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 10,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 11,
+			"column": 0
+		},
+		{
+			"type": "comment",
+			"content": "// If-else statement",
+			"line": 13,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "if",
+			"line": 14,
+			"column": 0
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 14,
+			"column": 3
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 14,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "==",
+			"line": 14,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 14,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 14,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 14,
+			"column": 12
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 15,
+			"column": 4
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 15,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 15,
+			"column": 7
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 15,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 15,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 15,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 16,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "else",
+			"line": 16,
+			"column": 2
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 16,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 17,
+			"column": 4
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 17,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 17,
+			"column": 7
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 17,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 17,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 17,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 18,
+			"column": 0
+		},
+		{
+			"type": "comment",
+			"content": "// Break and continue",
+			"line": 20,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "for",
+			"line": 21,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 21,
+			"column": 4
+		},
+		{
+			"type": "keyword",
+			"content": "in",
+			"line": 21,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 21,
+			"column": 9
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 21,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": ":",
+			"line": 21,
+			"column": 11
+		},
+		{
+			"type": "number",
+			"content": "10",
+			"line": 21,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 21,
+			"column": 14
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 21,
+			"column": 16
+		},
+		{
+			"type": "keyword",
+			"content": "if",
+			"line": 22,
+			"column": 4
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 22,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 22,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "==",
+			"line": 22,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "5",
+			"line": 22,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 22,
+			"column": 14
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 22,
+			"column": 16
+		},
+		{
+			"type": "keyword",
+			"content": "break",
+			"line": 23,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 23,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 24,
+			"column": 4
+		},
+		{
+			"type": "keyword",
+			"content": "if",
+			"line": 25,
+			"column": 4
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 25,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 25,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "<",
+			"line": 25,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "3",
+			"line": 25,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 25,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 25,
+			"column": 15
+		},
+		{
+			"type": "keyword",
+			"content": "continue",
+			"line": 26,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 26,
+			"column": 16
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 27,
+			"column": 4
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 28,
+			"column": 4
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 28,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 28,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "i",
+			"line": 28,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 28,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 28,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 29,
+			"column": 0
+		}
+	]
+}

--- a/testdata/highlighter/expected/operators.json
+++ b/testdata/highlighter/expected/operators.json
@@ -1,0 +1,418 @@
+{
+	"tokens": [
+		{
+			"type": "keyword",
+			"content": "OPENQASM",
+			"line": 1,
+			"column": 0
+		},
+		{
+			"type": "number",
+			"content": "3.0",
+			"line": 1,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 1,
+			"column": 12
+		},
+		{
+			"type": "comment",
+			"content": "// Arithmetic operators",
+			"line": 3,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 4,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "a",
+			"line": 4,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 4,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 4,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "+",
+			"line": 4,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "2",
+			"line": 4,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 4,
+			"column": 13
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 5,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "b",
+			"line": 5,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 5,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "3",
+			"line": 5,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "-",
+			"line": 5,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "4",
+			"line": 5,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 5,
+			"column": 13
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 6,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 6,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 6,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "5",
+			"line": 6,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "*",
+			"line": 6,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "6",
+			"line": 6,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 6,
+			"column": 13
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 7,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "d",
+			"line": 7,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 7,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "7",
+			"line": 7,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "/",
+			"line": 7,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "8",
+			"line": 7,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 7,
+			"column": 13
+		},
+		{
+			"type": "comment",
+			"content": "// Comparison operators",
+			"line": 9,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "if",
+			"line": 10,
+			"column": 0
+		},
+		{
+			"type": "punctuation",
+			"content": "(",
+			"line": 10,
+			"column": 3
+		},
+		{
+			"type": "identifier",
+			"content": "a",
+			"line": 10,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "==",
+			"line": 10,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "b",
+			"line": 10,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ")",
+			"line": 10,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "{",
+			"line": 10,
+			"column": 12
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 11,
+			"column": 4
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 11,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 11,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 11,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 11,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": "}",
+			"line": 12,
+			"column": 0
+		},
+		{
+			"type": "comment",
+			"content": "// Quantum operators",
+			"line": 14,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "cx",
+			"line": 15,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 15,
+			"column": 3
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 15,
+			"column": 4
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 15,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 15,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 15,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 15,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 15,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 15,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 15,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 15,
+			"column": 13
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 16,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 16,
+			"column": 2
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 16,
+			"column": 3
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 16,
+			"column": 4
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 16,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 16,
+			"column": 6
+		},
+		{
+			"type": "measurement",
+			"content": "measure",
+			"line": 17,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 17,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "->",
+			"line": 17,
+			"column": 10
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 17,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 17,
+			"column": 14
+		}
+	]
+}

--- a/testdata/highlighter/expected/registers.json
+++ b/testdata/highlighter/expected/registers.json
@@ -1,0 +1,502 @@
+{
+	"tokens": [
+		{
+			"type": "keyword",
+			"content": "OPENQASM",
+			"line": 1,
+			"column": 0
+		},
+		{
+			"type": "number",
+			"content": "3.0",
+			"line": 1,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 1,
+			"column": 12
+		},
+		{
+			"type": "comment",
+			"content": "// Register declarations",
+			"line": 3,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "qubit",
+			"line": 4,
+			"column": 0
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 4,
+			"column": 5
+		},
+		{
+			"type": "number",
+			"content": "5",
+			"line": 4,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 4,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 4,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 4,
+			"column": 10
+		},
+		{
+			"type": "keyword",
+			"content": "bit",
+			"line": 5,
+			"column": 0
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 5,
+			"column": 3
+		},
+		{
+			"type": "number",
+			"content": "5",
+			"line": 5,
+			"column": 4
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 5,
+			"column": 5
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 5,
+			"column": 7
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 5,
+			"column": 8
+		},
+		{
+			"type": "keyword",
+			"content": "qreg",
+			"line": 6,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "r",
+			"line": 6,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 6,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "10",
+			"line": 6,
+			"column": 7
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 6,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 6,
+			"column": 10
+		},
+		{
+			"type": "keyword",
+			"content": "creg",
+			"line": 7,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "m",
+			"line": 7,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 7,
+			"column": 6
+		},
+		{
+			"type": "number",
+			"content": "10",
+			"line": 7,
+			"column": 7
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 7,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 7,
+			"column": 10
+		},
+		{
+			"type": "comment",
+			"content": "// Quantum operations with registers",
+			"line": 9,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "h",
+			"line": 10,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 10,
+			"column": 2
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 10,
+			"column": 3
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 10,
+			"column": 4
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 10,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 10,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "cx",
+			"line": 11,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 11,
+			"column": 3
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 11,
+			"column": 4
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 11,
+			"column": 5
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 11,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": ",",
+			"line": 11,
+			"column": 7
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 11,
+			"column": 9
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 11,
+			"column": 10
+		},
+		{
+			"type": "number",
+			"content": "1",
+			"line": 11,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 11,
+			"column": 12
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 11,
+			"column": 13
+		},
+		{
+			"type": "keyword",
+			"content": "reset",
+			"line": 12,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 12,
+			"column": 6
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 12,
+			"column": 7
+		},
+		{
+			"type": "comment",
+			"content": "// Measurements with registers",
+			"line": 14,
+			"column": 0
+		},
+		{
+			"type": "measurement",
+			"content": "measure",
+			"line": 15,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 15,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 15,
+			"column": 9
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 15,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 15,
+			"column": 11
+		},
+		{
+			"type": "operator",
+			"content": "->",
+			"line": 15,
+			"column": 13
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 15,
+			"column": 16
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 15,
+			"column": 17
+		},
+		{
+			"type": "number",
+			"content": "0",
+			"line": 15,
+			"column": 18
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 15,
+			"column": 19
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 15,
+			"column": 20
+		},
+		{
+			"type": "measurement",
+			"content": "measure",
+			"line": 16,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 16,
+			"column": 8
+		},
+		{
+			"type": "operator",
+			"content": "->",
+			"line": 16,
+			"column": 10
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 16,
+			"column": 13
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 16,
+			"column": 14
+		},
+		{
+			"type": "comment",
+			"content": "// Array indexing",
+			"line": 18,
+			"column": 0
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 19,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "x",
+			"line": 19,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 19,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "q",
+			"line": 19,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 19,
+			"column": 9
+		},
+		{
+			"type": "number",
+			"content": "2",
+			"line": 19,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 19,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 19,
+			"column": 12
+		},
+		{
+			"type": "keyword",
+			"content": "let",
+			"line": 20,
+			"column": 0
+		},
+		{
+			"type": "identifier",
+			"content": "y",
+			"line": 20,
+			"column": 4
+		},
+		{
+			"type": "operator",
+			"content": "=",
+			"line": 20,
+			"column": 6
+		},
+		{
+			"type": "identifier",
+			"content": "c",
+			"line": 20,
+			"column": 8
+		},
+		{
+			"type": "punctuation",
+			"content": "[",
+			"line": 20,
+			"column": 9
+		},
+		{
+			"type": "number",
+			"content": "3",
+			"line": 20,
+			"column": 10
+		},
+		{
+			"type": "punctuation",
+			"content": "]",
+			"line": 20,
+			"column": 11
+		},
+		{
+			"type": "punctuation",
+			"content": ";",
+			"line": 20,
+			"column": 12
+		}
+	]
+}

--- a/testdata/highlighter/input/basic.qasm
+++ b/testdata/highlighter/input/basic.qasm
@@ -1,0 +1,9 @@
+OPENQASM 3.0;
+include "stdgates.inc";
+
+// This is a comment
+gate h q { }
+
+qubit q;
+h q;
+measure q -> c;

--- a/testdata/highlighter/input/builtins.qasm
+++ b/testdata/highlighter/input/builtins.qasm
@@ -1,0 +1,28 @@
+OPENQASM 3.0;
+
+// Builtin gates
+U(pi/2, 0, pi) q[0];
+CX q[0], q[1];
+
+// Builtin quantum operations
+reset q;
+barrier q;
+measure q -> c;
+
+// Builtin classical functions
+let angle = pi/2;
+let x = sin(angle);
+let y = cos(angle);
+let z = sqrt(x*x + y*y);
+
+// Builtin constants
+const real_pi = pi;
+const real_tau = tau;
+const real_euler = euler;
+
+// Hardware qubits
+$0 = U(0, 0, 0) $1;
+
+// Access control
+const int x = 1;
+mutable float y = 2.0;

--- a/testdata/highlighter/input/control_flow.qasm
+++ b/testdata/highlighter/input/control_flow.qasm
@@ -1,0 +1,29 @@
+OPENQASM 3.0;
+
+// For loop
+for i in [0:3] {
+    h q[i];
+}
+
+// While loop
+while (i > 0) {
+    i = i - 1;
+}
+
+// If-else statement
+if (x == 1) {
+    h q[0];
+} else {
+    x q[0];
+}
+
+// Break and continue
+for i in [0:10] {
+    if (i == 5) {
+        break;
+    }
+    if (i < 3) {
+        continue;
+    }
+    h q[i];
+}

--- a/testdata/highlighter/input/operators.qasm
+++ b/testdata/highlighter/input/operators.qasm
@@ -1,0 +1,17 @@
+OPENQASM 3.0;
+
+// Arithmetic operators
+let a = 1 + 2;
+let b = 3 - 4;
+let c = 5 * 6;
+let d = 7 / 8;
+
+// Comparison operators
+if (a == b) {
+    let x = 1;
+}
+
+// Quantum operators
+cx q[0], q[1];
+h q[0];
+measure q -> c;

--- a/testdata/highlighter/input/registers.qasm
+++ b/testdata/highlighter/input/registers.qasm
@@ -1,0 +1,20 @@
+OPENQASM 3.0;
+
+// Register declarations
+qubit[5] q;
+bit[5] c;
+qreg r[10];
+creg m[10];
+
+// Quantum operations with registers
+h q[0];
+cx q[0], q[1];
+reset q;
+
+// Measurements with registers
+measure q[0] -> c[0];
+measure q -> c;
+
+// Array indexing
+let x = q[2];
+let y = c[3];


### PR DESCRIPTION
Introduce new QASM test cases for control flow, operators, and registers, along with expected output files. Update existing QASM examples and enhance the highlighter to support new constructs in QASM 3.0.