### PR TITLE
Update .gitignore and enhance test output for color verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ vendor/
 # Task specific
 .task/
 vscode-qasm/node_modules/
+CLAUDE.md

--- a/highlight/highlight.go
+++ b/highlight/highlight.go
@@ -140,19 +140,19 @@ func (h *Highlighter) Highlight(input string) (string, error) {
 
 	// Create the lexer
 	lexer := qasm_gen.Newqasm3Lexer(inputStream)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	stream := antlr.NewCommonTokenStream(lexer, antlr.LexerDefaultTokenChannel)
 
 	// Clear previous tokens
 	h.tokens = make([]TokenInfo, 0)
 
-	// Walk through all tokens
-	for {
-		t := stream.LT(1)
-		if t.GetTokenType() == antlr.TokenEOF {
-			break
+	// Get all tokens including hidden ones (comments)
+	stream.Fill()
+	tokens := stream.GetAllTokens()
+
+	for _, t := range tokens {
+		if t.GetTokenType() != antlr.TokenEOF {
+			h.processToken(t)
 		}
-		h.processToken(t)
-		stream.Consume()
 	}
 
 	return h.ColoredString(), nil
@@ -292,7 +292,7 @@ func (h *Highlighter) getTokenType(t antlr.Token) TokenType {
 		return TokenMeasurement
 
 	// Numbers
-	case 92, 93, 96: // DecimalIntegerLiteral, HexIntegerLiteral, FloatLiteral
+	case 92, 93, 96, 104: // DecimalIntegerLiteral, HexIntegerLiteral, FloatLiteral, RealLiteral
 		return TokenNumber
 
 	// Strings

--- a/highlight/highlight_test.go
+++ b/highlight/highlight_test.go
@@ -134,6 +134,7 @@ measure q -> c;`
 	if !strings.Contains(output, string(Blue)) ||
 		!strings.Contains(output, string(Cyan)) ||
 		!strings.Contains(output, string(Yellow)) {
-		t.Error("Output does not contain expected custom colors")
+		t.Errorf("Output does not contain expected custom colors. Output: %q", output)
+		t.Errorf("Looking for Blue: %q, Cyan: %q, Yellow: %q", string(Blue), string(Cyan), string(Yellow))
 	}
 }


### PR DESCRIPTION
Improve the .gitignore file and enhance the test output to provide clearer information when expected colors are not found. Adjust the token stream handling to include hidden tokens for better processing.