### PR TITLE
Improve QASM formatting and add idempotency tests

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -639,10 +639,11 @@ func (f *Formatter) fixMalformedLine(line string) string {
 
 	// Fix comparison operators in if statements
 	if strings.Contains(line, "if") {
-		line = regexp.MustCompile(`==`).ReplaceAllString(line, " == ")
-		line = regexp.MustCompile(`!=`).ReplaceAllString(line, " != ")
-		line = regexp.MustCompile(`<=`).ReplaceAllString(line, " <= ")
-		line = regexp.MustCompile(`>=`).ReplaceAllString(line, " >= ")
+		// Use word boundaries and check for existing spacing to avoid duplicating spaces
+		line = regexp.MustCompile(`\s*==\s*`).ReplaceAllString(line, " == ")
+		line = regexp.MustCompile(`\s*!=\s*`).ReplaceAllString(line, " != ")
+		line = regexp.MustCompile(`\s*<=\s*`).ReplaceAllString(line, " <= ")
+		line = regexp.MustCompile(`\s*>=\s*`).ReplaceAllString(line, " >= ")
 	}
 
 	// Skip assignment operator processing for now

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -58,6 +58,18 @@ func TestFormatQASM(t *testing.T) {
 						i+1, expectedLines[i], actualLines[i])
 				}
 			}
+
+			// Test idempotency: format(format(input)) should equal format(input)
+			formattedTwice, err := FormatQASM(formatted)
+			if err != nil {
+				t.Errorf("Second FormatQASM() error = %v", err)
+				return
+			}
+
+			if formatted != formattedTwice {
+				t.Errorf("Formatter is not idempotent!\nFirst format:\n%s\nSecond format:\n%s",
+					formatted, formattedTwice)
+			}
 		})
 	}
 }
@@ -107,6 +119,18 @@ include "stdgates.qasm";`,
 			if formatted != tt.expected {
 				t.Errorf("FormatQASMWithConfig() = %v, want %v", formatted, tt.expected)
 			}
+
+			// Test idempotency for config-based formatting
+			formattedTwice, err := FormatQASMWithConfig(formatted, tt.config)
+			if err != nil {
+				t.Errorf("Second FormatQASMWithConfig() error = %v", err)
+				return
+			}
+
+			if formatted != formattedTwice {
+				t.Errorf("Config-based formatter is not idempotent!\nFirst format:\n%s\nSecond format:\n%s",
+					formatted, formattedTwice)
+			}
 		})
 	}
 }
@@ -143,6 +167,117 @@ invalid command;`,
 			err := ValidateQASM(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateQASM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestFormatterIdempotency tests specific edge cases for idempotency
+func TestFormatterIdempotency(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "compound statements",
+			input: `OPENQASM 3.0;include"stdgates.qasm";qubit[2]q;bit[2]c;hq[0];cxq[0],q[1];measureq->c;`,
+		},
+		{
+			name: "already formatted with empty lines",
+			input: `OPENQASM 3.0;
+include "stdgates.qasm";
+
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+measure q -> c;`,
+		},
+		{
+			name: "comments and empty lines",
+			input: `// Header comment
+OPENQASM 3.0;
+// Include comment
+include "stdgates.qasm";
+
+/* Block comment */
+qubit[2] q;
+bit[2] c;  // Trailing comment`,
+		},
+		{
+			name: "complex nested structures",
+			input: `OPENQASM 3.0;
+include "stdgates.qasm";
+
+gate bell_prep q0, q1 {
+    h q0;
+    cx q0, q1;
+}
+
+qubit[2] q;
+bit[2] c;
+
+if (c[0] == 1) {
+    x q[1];
+}`,
+		},
+		{
+			name: "malformed spacing",
+			input: `OPENQASM   3.0  ; include   "stdgates.qasm"   ;qubit [ 2 ] q ; bit[ 2]c;h  q[  0 ];`,
+		},
+		{
+			name: "empty and whitespace lines",
+			input: `OPENQASM 3.0;
+
+
+include "stdgates.qasm";   
+
+
+qubit[2] q;
+
+    
+bit[2] c;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// First format
+			formatted1, err := FormatQASM(tt.input)
+			if err != nil {
+				t.Errorf("First FormatQASM() error = %v", err)
+				return
+			}
+
+			// Second format (should be identical)
+			formatted2, err := FormatQASM(formatted1)
+			if err != nil {
+				t.Errorf("Second FormatQASM() error = %v", err)
+				return
+			}
+
+			// Third format (extra verification)
+			formatted3, err := FormatQASM(formatted2)
+			if err != nil {
+				t.Errorf("Third FormatQASM() error = %v", err)
+				return
+			}
+
+			// Check that all three are identical
+			if formatted1 != formatted2 {
+				t.Errorf("Formatter is not idempotent (1st vs 2nd)!\nFirst format:\n%s\nSecond format:\n%s",
+					formatted1, formatted2)
+			}
+
+			if formatted2 != formatted3 {
+				t.Errorf("Formatter is not idempotent (2nd vs 3rd)!\nSecond format:\n%s\nThird format:\n%s",
+					formatted2, formatted3)
+			}
+
+			// Additional check: verify length consistency
+			if len(formatted1) != len(formatted2) || len(formatted2) != len(formatted3) {
+				t.Errorf("Formatter output length inconsistent!\nLengths: %d, %d, %d",
+					len(formatted1), len(formatted2), len(formatted3))
 			}
 		})
 	}


### PR DESCRIPTION
Enhance spacing handling for comparison operators in QASM formatting and introduce tests to ensure idempotency of formatting functions.