### PR TITLE
Add linting capabilities for QASM files and clean up formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 * **QASM 3.0 Parsing**: Parses OpenQASM 3.0 files into an Abstract Syntax Tree (AST).
 * **QASM 3.0 Formatting**: Formats QASM 3.0 files to adhere to a consistent style.
+* **QASM 3.0 Linting**: Checks QASM files for style and semantic issues using configurable YAML-based rules.
 * **VSCode Extension**: Provides language support for OpenQASM 3.0 in Visual Studio Code with syntax highlighting, formatting, and Language Server Protocol (LSP) integration.
 
 ## Installation
@@ -34,7 +35,7 @@ To build `qasmtools` from source, ensure you have Go installed (version 1.16 or 
 
 ## Usage
 
-The `qasm` executable provides two main commands: `fmt` for formatting and `parse` for parsing QASM files.
+The `qasm` executable provides three main commands: `fmt` for formatting, `lint` for linting, and `highlight` for syntax highlighting of QASM files.
 
 ### Formatting QASM Files
 
@@ -69,19 +70,46 @@ qasm fmt --check *.qasm
 qasm fmt -i 4 input.qasm
 ```
 
-### Parsing QASM Files
+### Linting QASM Files
 
-To parse and validate a QASM file:
-
-```bash
-qasm parse <file>
-```
-
-Example:
+To check QASM files for style and semantic issues:
 
 ```bash
-qasm parse input.qasm
+qasm lint [files...]
 ```
+
+Options:
+
+- `--rules`: Directory containing custom rule files (default: use embedded rules)
+- `-d, --disable`: Disable specific rules (e.g., QAS001,QAS002)
+- `-e, --enable-only`: Enable only specific rules
+- `--format`: Output format (text, json)
+- `-q, --quiet`: Suppress info and warning messages
+
+Examples:
+
+```bash
+# Lint a single file
+qasm lint input.qasm
+
+# Lint multiple files
+qasm lint *.qasm
+
+# Disable specific rules
+qasm lint --disable=QAS001,QAS003 input.qasm
+
+# Enable only specific rules
+qasm lint --enable-only=QAS002 input.qasm
+
+# Use custom rules directory
+qasm lint --rules=custom/rules input.qasm
+```
+
+#### Built-in Rules
+
+- **QAS001**: `no-unused-qubit` - Detects qubits that are declared but never used
+- **QAS002**: `gate-naming-convention` - Enforces naming conventions for gates
+- **QAS003**: `max-qubits` - Warns if qubit count exceeds threshold
 
 ## VSCode Extension
 
@@ -150,6 +178,7 @@ task vscode:logs
   * `grammar/`: Contains the ANTLR grammar files for QASM 3.0
   * `gen/`: Contains generated parser code
 * `formatter/`: Implements the QASM 3.0 formatting logic
+* `lint/`: QASM 3.0 linting engine with YAML-based rules
 * `highlight/`: Syntax highlighting implementation for LSP
 * `vscode-qasm/`: VSCode extension for OpenQASM 3.0 language support
   * `syntaxes/`: TextMate grammar for syntax highlighting

--- a/cmd/qasm/version.go
+++ b/cmd/qasm/version.go
@@ -4,10 +4,10 @@ package main
 var (
 	// Version is the current version of the qasm CLI
 	Version = "0.2.0"
-	
+
 	// BuildDate is the date when the binary was built
 	BuildDate = "unknown"
-	
+
 	// GitCommit is the git commit hash
 	GitCommit = "unknown"
 )

--- a/cmd/qasmlsp/main.go
+++ b/cmd/qasmlsp/main.go
@@ -99,7 +99,7 @@ func textDocumentDidChange(context *glsp.Context, params *protocol.DidChangeText
 		for i, changeInterface := range params.ContentChanges {
 			if change, ok := changeInterface.(protocol.TextDocumentContentChangeEvent); ok {
 				log.Info("Processing change", "index", i, "text_length", len(change.Text), "has_range", change.Range != nil)
-				
+
 				// Check if this is a full document change (no range specified)
 				if change.Range == nil {
 					// Full document replacement - this is what we want for format results
@@ -109,7 +109,7 @@ func textDocumentDidChange(context *glsp.Context, params *protocol.DidChangeText
 				}
 			}
 		}
-		
+
 		// If we only have incremental changes from formatting, don't update the cache
 		// The formatter has already updated the cache, so incremental changes might be inconsistent
 		log.Info("Only incremental changes detected - skipping document cache update to preserve formatter consistency")

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -535,39 +535,39 @@ func (f *Formatter) preprocessMalformedQASM(content string) string {
 func (f *Formatter) splitCompoundStatements(content string) string {
 	lines := strings.Split(content, "\n")
 	var processedLines []string
-	
+
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			processedLines = append(processedLines, line)
 			continue
 		}
-		
+
 		// Skip lines that are only comments
 		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
 			processedLines = append(processedLines, line)
 			continue
 		}
-		
+
 		// Count semicolons to determine if this line has multiple statements
 		semicolonCount := strings.Count(line, ";")
-		
+
 		// If there's only 0 or 1 semicolon, keep the line as-is
 		if semicolonCount <= 1 {
 			processedLines = append(processedLines, line)
 			continue
 		}
-		
+
 		// Split compound statements on lines with multiple semicolons
 		var statements []string
 		parts := strings.Split(line, ";")
-		
+
 		for i, part := range parts {
 			part = strings.TrimSpace(part)
 			if part == "" {
 				continue
 			}
-			
+
 			// Check if this part starts with a comment - if so, attach it to the previous statement
 			if strings.HasPrefix(part, "//") && len(statements) > 0 {
 				// This is a trailing comment, attach it to the previous statement
@@ -580,7 +580,7 @@ func (f *Formatter) splitCompoundStatements(content string) string {
 				statements = append(statements, part)
 			}
 		}
-		
+
 		processedLines = append(processedLines, statements...)
 	}
 

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -222,7 +222,7 @@ if (c[0] == 1) {
 }`,
 		},
 		{
-			name: "malformed spacing",
+			name:  "malformed spacing",
 			input: `OPENQASM   3.0  ; include   "stdgates.qasm"   ;qubit [ 2 ] q ; bit[ 2]c;h  q[  0 ];`,
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,5 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.14.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -99,4 +99,5 @@ golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lint/checker.go
+++ b/lint/checker.go
@@ -1,0 +1,154 @@
+package lint
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/orangekame3/qasmtools/parser"
+)
+
+// UnusedQubitChecker checks for unused qubit declarations
+type UnusedQubitChecker struct{}
+
+func (c *UnusedQubitChecker) Check(node parser.Node, context *CheckContext) []*Violation {
+	var violations []*Violation
+
+	// Only check qubit declarations
+	if decl, ok := node.(*parser.QuantumDeclaration); ok && decl.Type == "qubit" {
+		qubitName := decl.Identifier
+		
+		// Check if the qubit is used anywhere
+		if usages, exists := context.UsageMap[qubitName]; !exists || len(usages) == 0 {
+			violation := &Violation{
+				File:     context.File,
+				Line:     decl.Position.Line,
+				Column:   decl.Position.Column,
+				NodeName: qubitName,
+				Message:  "Qubit '" + qubitName + "' is declared but never used.",
+				Severity: SeverityWarning,
+			}
+			violations = append(violations, violation)
+		}
+	}
+
+	return violations
+}
+
+// GateNamingChecker checks gate naming conventions
+type GateNamingChecker struct {
+	Pattern *regexp.Regexp
+}
+
+func NewGateNamingChecker(pattern string) *GateNamingChecker {
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		// Fallback to default pattern
+		regex = regexp.MustCompile("^[a-z][a-z0-9_]*$")
+	}
+	
+	return &GateNamingChecker{
+		Pattern: regex,
+	}
+}
+
+func (c *GateNamingChecker) Check(node parser.Node, context *CheckContext) []*Violation {
+	var violations []*Violation
+
+	// Only check gate declarations
+	if gate, ok := node.(*parser.GateDefinition); ok {
+		gateName := gate.Name
+		
+		if !c.Pattern.MatchString(gateName) {
+			violation := &Violation{
+				File:     context.File,
+				Line:     gate.Position.Line,
+				Column:   gate.Position.Column,
+				NodeName: gateName,
+				Message:  "Gate '" + gateName + "' does not follow naming convention.",
+				Severity: SeverityWarning,
+			}
+			violations = append(violations, violation)
+		}
+	}
+
+	return violations
+}
+
+// MaxQubitsChecker checks for maximum qubit count
+type MaxQubitsChecker struct {
+	MaxCount int
+}
+
+func NewMaxQubitsChecker(maxCount int) *MaxQubitsChecker {
+	return &MaxQubitsChecker{
+		MaxCount: maxCount,
+	}
+}
+
+func (c *MaxQubitsChecker) Check(node parser.Node, context *CheckContext) []*Violation {
+	var violations []*Violation
+
+	// Count qubits in the entire program
+	qubitCount := 0
+	for _, stmt := range context.Program.Statements {
+		if decl, ok := stmt.(*parser.QuantumDeclaration); ok && decl.Type == "qubit" {
+			// TODO: Handle array sizes properly
+			qubitCount += 1 // For now, count each declaration as 1
+		}
+	}
+
+	if qubitCount > c.MaxCount {
+		// Only report once per program
+		if decl, ok := node.(*parser.QuantumDeclaration); ok && decl.Type == "qubit" {
+			violation := &Violation{
+				File:     context.File,
+				Line:     decl.Position.Line,
+				Column:   decl.Position.Column,
+				NodeName: "program",
+				Message:  fmt.Sprintf("Program uses %d qubits, exceeding maximum of %d", qubitCount, c.MaxCount),
+				Severity: SeverityWarning,
+			}
+			violations = append(violations, violation)
+		}
+	}
+
+	return violations
+}
+
+// CreateChecker creates a checker based on rule configuration
+func CreateChecker(rule *Rule) RuleChecker {
+	switch rule.Match.Type {
+	case "declaration":
+		switch rule.Match.Kind {
+		case "qubit":
+			for _, check := range rule.Check {
+				switch check.Type {
+				case "usage":
+					if check.NotFound {
+						return &UnusedQubitChecker{}
+					}
+				case "count":
+					if check.Max > 0 {
+						return NewMaxQubitsChecker(check.Max)
+					}
+				}
+			}
+		case "gate":
+			for _, check := range rule.Check {
+				if check.Type == "naming" && check.Pattern != "" {
+					return NewGateNamingChecker(check.Pattern)
+				}
+			}
+		}
+	}
+
+	// Return a no-op checker if no specific checker is found
+	return &NoOpChecker{}
+}
+
+// NoOpChecker is a checker that does nothing
+type NoOpChecker struct{}
+
+func (c *NoOpChecker) Check(node parser.Node, context *CheckContext) []*Violation {
+	return nil
+}

--- a/lint/checker.go
+++ b/lint/checker.go
@@ -16,7 +16,7 @@ func (c *UnusedQubitChecker) Check(node parser.Node, context *CheckContext) []*V
 	// Only check qubit declarations
 	if decl, ok := node.(*parser.QuantumDeclaration); ok && decl.Type == "qubit" {
 		qubitName := decl.Identifier
-		
+
 		// Check if the qubit is used anywhere
 		if usages, exists := context.UsageMap[qubitName]; !exists || len(usages) == 0 {
 			violation := &Violation{
@@ -45,7 +45,7 @@ func NewGateNamingChecker(pattern string) *GateNamingChecker {
 		// Fallback to default pattern
 		regex = regexp.MustCompile("^[a-z][a-z0-9_]*$")
 	}
-	
+
 	return &GateNamingChecker{
 		Pattern: regex,
 	}
@@ -57,7 +57,7 @@ func (c *GateNamingChecker) Check(node parser.Node, context *CheckContext) []*Vi
 	// Only check gate declarations
 	if gate, ok := node.(*parser.GateDefinition); ok {
 		gateName := gate.Name
-		
+
 		if !c.Pattern.MatchString(gateName) {
 			violation := &Violation{
 				File:     context.File,

--- a/lint/loader.go
+++ b/lint/loader.go
@@ -24,7 +24,7 @@ type RuleLoader struct {
 func NewRuleLoader(rulesDir string) *RuleLoader {
 	// Use embedded rules if no custom directory specified or default directory
 	useEmbedded := rulesDir == "" || rulesDir == "lint/rules"
-	
+
 	return &RuleLoader{
 		rulesDir:    rulesDir,
 		useEmbedded: useEmbedded,

--- a/lint/loader.go
+++ b/lint/loader.go
@@ -1,0 +1,162 @@
+package lint
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed rules/*.yaml
+var embeddedRulesFS embed.FS
+
+// RuleLoader loads rules from YAML files
+type RuleLoader struct {
+	rulesDir    string
+	useEmbedded bool
+}
+
+// NewRuleLoader creates a new rule loader
+func NewRuleLoader(rulesDir string) *RuleLoader {
+	// Use embedded rules if no custom directory specified or default directory
+	useEmbedded := rulesDir == "" || rulesDir == "lint/rules"
+	
+	return &RuleLoader{
+		rulesDir:    rulesDir,
+		useEmbedded: useEmbedded,
+	}
+}
+
+// LoadRules loads all rules from the rules directory
+func (l *RuleLoader) LoadRules() ([]*Rule, error) {
+	if l.useEmbedded {
+		return l.loadEmbeddedRules()
+	}
+	return l.loadFileSystemRules()
+}
+
+// loadEmbeddedRules loads rules from embedded files
+func (l *RuleLoader) loadEmbeddedRules() ([]*Rule, error) {
+	var rules []*Rule
+
+	err := fs.WalkDir(embeddedRulesFS, "rules", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || (!strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml")) {
+			return nil
+		}
+
+		data, err := embeddedRulesFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded rule %s: %w", path, err)
+		}
+
+		rule, err := l.parseRuleYAML(data)
+		if err != nil {
+			return fmt.Errorf("failed to parse embedded rule %s: %w", path, err)
+		}
+
+		if rule.Enabled {
+			rules = append(rules, rule)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rules, nil
+}
+
+// loadFileSystemRules loads rules from filesystem
+func (l *RuleLoader) loadFileSystemRules() ([]*Rule, error) {
+	var rules []*Rule
+
+	err := filepath.Walk(l.rulesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml") {
+			return nil
+		}
+
+		rule, err := l.loadRuleFromFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to load rule from %s: %w", path, err)
+		}
+
+		if rule.Enabled {
+			rules = append(rules, rule)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rules, nil
+}
+
+// loadRuleFromFile loads a single rule from a YAML file
+func (l *RuleLoader) loadRuleFromFile(filename string) (*Rule, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.parseRuleYAML(data)
+}
+
+// parseRuleYAML parses YAML data into a Rule struct
+func (l *RuleLoader) parseRuleYAML(data []byte) (*Rule, error) {
+	var rule Rule
+	err := yaml.Unmarshal(data, &rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Validate required fields
+	if rule.ID == "" {
+		return nil, fmt.Errorf("rule ID is required")
+	}
+	if rule.Name == "" {
+		return nil, fmt.Errorf("rule name is required")
+	}
+	if rule.Message == "" {
+		return nil, fmt.Errorf("rule message is required")
+	}
+
+	// Set defaults
+	if rule.Level == "" {
+		rule.Level = SeverityWarning
+	}
+
+	return &rule, nil
+}
+
+// LoadRule loads a specific rule by ID
+func (l *RuleLoader) LoadRule(ruleID string) (*Rule, error) {
+	rules, err := l.LoadRules()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range rules {
+		if rule.ID == ruleID {
+			return rule, nil
+		}
+	}
+
+	return nil, fmt.Errorf("rule %s not found", ruleID)
+}

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -1,0 +1,82 @@
+package lint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/orangekame3/qasmtools/parser"
+)
+
+// Severity represents the severity level of a lint rule
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// Rule represents a lint rule loaded from YAML
+type Rule struct {
+	ID          string    `yaml:"id"`
+	Name        string    `yaml:"name"`
+	Description string    `yaml:"description"`
+	Level       Severity  `yaml:"level"`
+	Enabled     bool      `yaml:"enabled"`
+	Match       Match     `yaml:"match"`
+	Check       []Check   `yaml:"check"`
+	Message     string    `yaml:"message"`
+	Tags        []string  `yaml:"tags"`
+	Fixable     bool      `yaml:"fixable"`
+}
+
+// Match defines what AST nodes to match
+type Match struct {
+	Type string `yaml:"type"` // declaration, statement, expression, etc.
+	Kind string `yaml:"kind"` // qubit, gate, measure, etc.
+}
+
+// Check defines what to check on matched nodes
+type Check struct {
+	Type     string `yaml:"type"`     // usage, naming, count, etc.
+	NotFound bool   `yaml:"not_found"` // for usage checks
+	Pattern  string `yaml:"pattern"`   // for naming checks
+	Max      int    `yaml:"max"`       // for count checks
+	Min      int    `yaml:"min"`       // for count checks
+}
+
+// Violation represents a rule violation
+type Violation struct {
+	Rule     *Rule
+	Message  string
+	File     string
+	Line     int
+	Column   int
+	Severity Severity
+	NodeName string
+}
+
+// String returns a formatted string representation of the violation
+func (v *Violation) String() string {
+	return fmt.Sprintf("%s:%d:%d: %s [%s] %s", 
+		v.File, v.Line, v.Column, v.Severity, v.Rule.ID, v.Message)
+}
+
+// RuleChecker checks a specific rule against AST nodes
+type RuleChecker interface {
+	Check(node parser.Node, context *CheckContext) []*Violation
+}
+
+// CheckContext provides context for rule checking
+type CheckContext struct {
+	File     string
+	Program  *parser.Program
+	UsageMap map[string][]parser.Node // For tracking symbol usage
+}
+
+// expandMessage replaces template variables in the message
+func (r *Rule) expandMessage(nodeName string) string {
+	message := r.Message
+	message = strings.ReplaceAll(message, "{{ name }}", nodeName)
+	return message
+}

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -18,16 +18,16 @@ const (
 
 // Rule represents a lint rule loaded from YAML
 type Rule struct {
-	ID          string    `yaml:"id"`
-	Name        string    `yaml:"name"`
-	Description string    `yaml:"description"`
-	Level       Severity  `yaml:"level"`
-	Enabled     bool      `yaml:"enabled"`
-	Match       Match     `yaml:"match"`
-	Check       []Check   `yaml:"check"`
-	Message     string    `yaml:"message"`
-	Tags        []string  `yaml:"tags"`
-	Fixable     bool      `yaml:"fixable"`
+	ID          string   `yaml:"id"`
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Level       Severity `yaml:"level"`
+	Enabled     bool     `yaml:"enabled"`
+	Match       Match    `yaml:"match"`
+	Check       []Check  `yaml:"check"`
+	Message     string   `yaml:"message"`
+	Tags        []string `yaml:"tags"`
+	Fixable     bool     `yaml:"fixable"`
 }
 
 // Match defines what AST nodes to match
@@ -38,7 +38,7 @@ type Match struct {
 
 // Check defines what to check on matched nodes
 type Check struct {
-	Type     string `yaml:"type"`     // usage, naming, count, etc.
+	Type     string `yaml:"type"`      // usage, naming, count, etc.
 	NotFound bool   `yaml:"not_found"` // for usage checks
 	Pattern  string `yaml:"pattern"`   // for naming checks
 	Max      int    `yaml:"max"`       // for count checks
@@ -58,7 +58,7 @@ type Violation struct {
 
 // String returns a formatted string representation of the violation
 func (v *Violation) String() string {
-	return fmt.Sprintf("%s:%d:%d: %s [%s] %s", 
+	return fmt.Sprintf("%s:%d:%d: %s [%s] %s",
 		v.File, v.Line, v.Column, v.Severity, v.Rule.ID, v.Message)
 }
 

--- a/lint/rules/QAS001_no_unused_qubit.yaml
+++ b/lint/rules/QAS001_no_unused_qubit.yaml
@@ -1,0 +1,17 @@
+id: QAS001
+name: no-unused-qubit
+description: "Detects qubits that are declared but never used."
+level: warning
+enabled: true
+
+match:
+  type: declaration
+  kind: qubit
+
+check:
+  - type: usage
+    not_found: true
+
+message: "Qubit '{{ name }}' is declared but never used."
+tags: [qasm3, readability]
+fixable: false

--- a/lint/rules/QAS002_gate_naming_convention.yaml
+++ b/lint/rules/QAS002_gate_naming_convention.yaml
@@ -1,0 +1,17 @@
+id: QAS002
+name: gate-naming-convention
+description: "Enforces naming conventions for gates."
+level: warning
+enabled: true
+
+match:
+  type: declaration
+  kind: gate
+
+check:
+  - type: naming
+    pattern: "^[a-z][a-z0-9_]*$"
+
+message: "Gate '{{ name }}' does not follow naming convention (should be lowercase with underscores)."
+tags: [qasm3, naming, style]
+fixable: false

--- a/lint/rules/QAS003_max_qubits.yaml
+++ b/lint/rules/QAS003_max_qubits.yaml
@@ -1,0 +1,17 @@
+id: QAS003
+name: max-qubits
+description: "Warns if qubit count exceeds threshold."
+level: warning
+enabled: true
+
+match:
+  type: declaration
+  kind: qubit
+
+check:
+  - type: count
+    max: 100
+
+message: "Program uses too many qubits (maximum recommended: 100)."
+tags: [qasm3, performance, scale]
+fixable: false

--- a/lint/runner.go
+++ b/lint/runner.go
@@ -1,0 +1,196 @@
+package lint
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/orangekame3/qasmtools/parser"
+)
+
+// Linter is the main linter engine
+type Linter struct {
+	rules   []*Rule
+	loader  *RuleLoader
+	checkers map[string]RuleChecker
+}
+
+// NewLinter creates a new linter instance
+func NewLinter(rulesDir string) *Linter {
+	return &Linter{
+		loader:   NewRuleLoader(rulesDir),
+		checkers: make(map[string]RuleChecker),
+	}
+}
+
+// LoadRules loads all rules and creates corresponding checkers
+func (l *Linter) LoadRules() error {
+	rules, err := l.loader.LoadRules()
+	if err != nil {
+		return err
+	}
+
+	l.rules = rules
+	
+	// Create checkers for each rule
+	for _, rule := range rules {
+		checker := CreateChecker(rule)
+		l.checkers[rule.ID] = checker
+	}
+
+	return nil
+}
+
+// LintFile lints a single QASM file
+func (l *Linter) LintFile(filename string) ([]*Violation, error) {
+	// Parse the file
+	p := parser.NewParser()
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	result := p.ParseWithErrors(string(content))
+	if result.HasErrors() && result.Program == nil {
+		return nil, fmt.Errorf("failed to parse file: %v", result.Errors)
+	}
+
+	// Build usage map for symbol tracking
+	usageMap := l.buildUsageMap(result.Program)
+
+	// Create check context
+	context := &CheckContext{
+		File:     filename,
+		Program:  result.Program,
+		UsageMap: usageMap,
+	}
+
+	var allViolations []*Violation
+
+	// Run each rule against the AST
+	for _, rule := range l.rules {
+		checker := l.checkers[rule.ID]
+		violations := l.runRuleOnProgram(rule, checker, result.Program, context)
+		
+		// Set rule reference for each violation
+		for _, violation := range violations {
+			violation.Rule = rule
+			violation.Severity = rule.Level
+		}
+		
+		allViolations = append(allViolations, violations...)
+	}
+
+	return allViolations, nil
+}
+
+// runRuleOnProgram runs a single rule against the entire program
+func (l *Linter) runRuleOnProgram(rule *Rule, checker RuleChecker, program *parser.Program, context *CheckContext) []*Violation {
+	var violations []*Violation
+
+	// Check version statement
+	if program.Version != nil {
+		if l.matchesRule(rule, program.Version) {
+			nodeViolations := checker.Check(program.Version, context)
+			violations = append(violations, nodeViolations...)
+		}
+	}
+
+	// Check all statements (includes Include statements)
+	for _, stmt := range program.Statements {
+		if l.matchesRule(rule, stmt) {
+			nodeViolations := checker.Check(stmt, context)
+			violations = append(violations, nodeViolations...)
+		}
+	}
+
+	return violations
+}
+
+// matchesRule checks if an AST node matches the rule's match criteria
+func (l *Linter) matchesRule(rule *Rule, node parser.Node) bool {
+	switch rule.Match.Type {
+	case "declaration":
+		switch rule.Match.Kind {
+		case "qubit":
+			if decl, ok := node.(*parser.QuantumDeclaration); ok {
+				return decl.Type == "qubit"
+			}
+			return false
+		case "gate":
+			_, ok := node.(*parser.GateDefinition)
+			return ok
+		case "classical":
+			_, ok := node.(*parser.ClassicalDeclaration)
+			return ok
+		}
+	case "statement":
+		// All statements match
+		return true
+	case "expression":
+		// Handle expression matching if needed
+		return false
+	}
+
+	return false
+}
+
+// buildUsageMap builds a map of symbol names to their usage locations
+func (l *Linter) buildUsageMap(program *parser.Program) map[string][]parser.Node {
+	usageMap := make(map[string][]parser.Node)
+
+	// Walk through all statements and collect symbol usage
+	for _, stmt := range program.Statements {
+		l.collectSymbolUsage(stmt, usageMap)
+	}
+
+	return usageMap
+}
+
+// collectSymbolUsage recursively collects symbol usage from AST nodes
+func (l *Linter) collectSymbolUsage(node parser.Node, usageMap map[string][]parser.Node) {
+	switch n := node.(type) {
+	case *parser.GateCall:
+		// Record usage of qubits in gate calls
+		for _, qubit := range n.Qubits {
+			if id, ok := qubit.(*parser.Identifier); ok {
+				usageMap[id.Name] = append(usageMap[id.Name], node)
+			}
+		}
+	case *parser.Measurement:
+		// Record usage of qubits and classical bits in measurements
+		if id, ok := n.Qubit.(*parser.Identifier); ok {
+			usageMap[id.Name] = append(usageMap[id.Name], node)
+		}
+		if id, ok := n.Target.(*parser.Identifier); ok {
+			usageMap[id.Name] = append(usageMap[id.Name], node)
+		}
+	// Add more cases as needed for other statement types
+	}
+}
+
+// LintFiles lints multiple files
+func (l *Linter) LintFiles(filenames []string) ([]*Violation, error) {
+	var allViolations []*Violation
+
+	for _, filename := range filenames {
+		violations, err := l.LintFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to lint %s: %w", filename, err)
+		}
+		allViolations = append(allViolations, violations...)
+	}
+
+	return allViolations, nil
+}
+
+// LintDirectory lints all QASM files in a directory
+func (l *Linter) LintDirectory(dir string) ([]*Violation, error) {
+	pattern := filepath.Join(dir, "*.qasm")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.LintFiles(files)
+}

--- a/lint/runner.go
+++ b/lint/runner.go
@@ -10,8 +10,8 @@ import (
 
 // Linter is the main linter engine
 type Linter struct {
-	rules   []*Rule
-	loader  *RuleLoader
+	rules    []*Rule
+	loader   *RuleLoader
 	checkers map[string]RuleChecker
 }
 
@@ -31,7 +31,7 @@ func (l *Linter) LoadRules() error {
 	}
 
 	l.rules = rules
-	
+
 	// Create checkers for each rule
 	for _, rule := range rules {
 		checker := CreateChecker(rule)
@@ -71,13 +71,13 @@ func (l *Linter) LintFile(filename string) ([]*Violation, error) {
 	for _, rule := range l.rules {
 		checker := l.checkers[rule.ID]
 		violations := l.runRuleOnProgram(rule, checker, result.Program, context)
-		
+
 		// Set rule reference for each violation
 		for _, violation := range violations {
 			violation.Rule = rule
 			violation.Severity = rule.Level
 		}
-		
+
 		allViolations = append(allViolations, violations...)
 	}
 
@@ -165,7 +165,7 @@ func (l *Linter) collectSymbolUsage(node parser.Node, usageMap map[string][]pars
 		if id, ok := n.Target.(*parser.Identifier); ok {
 			usageMap[id.Name] = append(usageMap[id.Name], node)
 		}
-	// Add more cases as needed for other statement types
+		// Add more cases as needed for other statement types
 	}
 }
 


### PR DESCRIPTION
Introduce linting for QASM files with configurable rules and improve code formatting by removing unnecessary whitespace across multiple files.