### PR TITLE
Remove unnecessary Pages setup in deployment workflow

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -66,12 +66,7 @@ jobs:
       working-directory: ./playground
       run: |
         npm run build
-        touch out/.nojekyll
-
-    - name: Setup Pages
-      uses: actions/configure-pages@v5
-      with:
-        static_site_generator: next
+        touch ./out/.nojekyll
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Eliminate redundant setup steps for Pages in the deployment workflow to streamline the process.