### PR TITLE
Add support for escaped string samples in QASMSample interface

### DIFF
--- a/playground/src/data/samples.ts
+++ b/playground/src/data/samples.ts
@@ -3,7 +3,7 @@ export interface QASMSample {
   name: string;
   description: string;
   difficulty: 'beginner' | 'intermediate' | 'advanced';
-  category: 'basic' | 'algorithms' | 'gates' | 'measurement' | 'complex';
+  category: 'basic' | 'algorithms' | 'gates' | 'measurement' | 'complex' | 'string';
   code: string;
 }
 
@@ -53,6 +53,30 @@ measure q[0]->c[0];measure q[1]->c[1];measure q[2]->c[2];`
     difficulty: 'advanced',
     category: 'complex',
     code: `OPENQASM 3.0;include"stdgates.qasm";qubit[3]q;bit[2]c;h q[0];h q[1];cx q[1],q[2];cx q[0],q[1];h q[0];measure q[0]->c[0];measure q[1]->c[1];if(c[1]==1)x q[2];if(c[0]==1)z q[2];`
+  },
+  {
+    id: 'chain-cnot-escaped',
+    name: 'Chain CNOT (Escaped String)',
+    description: 'JSON-style escaped string with \\n and \\" - enable Unescape to format properly',
+    difficulty: 'beginner',
+    category: 'string',
+    code: `"OPENQASM 3.0;\\ninclude \\"stdgates.inc\\";\\nqubit[5] q;\\nbit[5] c;\\n\\nh q[0];\\ncx q[0], q[1];\\ncx q[1], q[2];\\ncx q[2], q[3];\\ncx q[3], q[4];\\nc = measure q;"`
+  },
+  {
+    id: 'bell-state-escaped',
+    name: 'Bell State (Escaped String)',
+    description: 'Classic Bell state as an escaped JSON string - try with Unescape enabled',
+    difficulty: 'beginner',
+    category: 'string',
+    code: `"OPENQASM 3.0;\\ninclude \\"stdgates.inc\\";\\nqubit[2] q;\\nbit[2] c;\\nh q[0];\\ncx q[0], q[1];\\nmeasure q -> c;"`
+  },
+  {
+    id: 'complex-circuit-escaped',
+    name: 'Complex Circuit (Escaped String)',
+    description: 'Multi-gate quantum circuit with conditional logic as escaped string',
+    difficulty: 'intermediate',
+    category: 'string',
+    code: `"OPENQASM 3.0;\\ninclude \\"stdgates.inc\\";\\nqubit[3] q;\\nbit[3] c;\\n\\n// Initialize superposition\\nh q[0];\\nh q[1];\\nh q[2];\\n\\n// Apply gates\\ncx q[0], q[1];\\ncz q[1], q[2];\\nrx(pi/4) q[0];\\n\\n// Measurement and conditional\\nmeasure q[0] -> c[0];\\nif (c[0] == 1) x q[1];\\nmeasure q -> c;"`
   }
 ];
 
@@ -62,7 +86,8 @@ export const sampleCategories = [
   { id: 'algorithms', name: 'Algorithms', icon: '🧮' },
   { id: 'gates', name: 'Gate Demos', icon: '⚡' },
   { id: 'measurement', name: 'Measurement', icon: '📊' },
-  { id: 'complex', name: 'Advanced', icon: '🚀' }
+  { id: 'complex', name: 'Advanced', icon: '🚀' },
+  { id: 'string', name: 'Escaped Strings', icon: '📝' }
 ];
 
 export const difficultyColors = {


### PR DESCRIPTION
Introduce a new category for escaped string samples in the QASMSample interface and add several examples demonstrating their usage.