### PR TITLE
Release for v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.1](https://github.com/orangekame3/qasmtools/compare/v0.2.0...v0.2.1) - 2025-07-01
+- Refactor parser generation in release workflow and GoReleaser configuration by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/47
+
 ## [v0.2.0](https://github.com/orangekame3/qasmtools/commits/v0.2.0) - 2025-07-01
 - Add initial quantum circuit in QASM format by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/1
 - Update README with usage instructions and project structure by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/2

--- a/cmd/qasm/version.go
+++ b/cmd/qasm/version.go
@@ -3,7 +3,7 @@ package main
 // Version information for the QASM CLI tool
 var (
 	// Version is the current version of the qasm CLI
-	Version = "0.2.0"
+	Version = "0.2.1"
 
 	// BuildDate is the date when the binary was built
 	BuildDate = "unknown"


### PR DESCRIPTION
This pull request is for the next release as v0.2.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Refactor parser generation in release workflow and GoReleaser configuration by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/47


**Full Changelog**: https://github.com/orangekame3/qasmtools/compare/v0.2.0...v0.2.1