### PR TITLE
Release for v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.3](https://github.com/orangekame3/qasmtools/compare/v0.2.2...v0.2.3) - 2025-07-01
+- Remove Java setup and parser generation from release workflow by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/51
+
 ## [v0.2.2](https://github.com/orangekame3/qasmtools/compare/v0.2.1...v0.2.2) - 2025-07-01
 - Add GitHub Action for committing generated parser files and update GoReleaser config by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/49
 

--- a/cmd/qasm/version.go
+++ b/cmd/qasm/version.go
@@ -3,7 +3,7 @@ package main
 // Version information for the QASM CLI tool
 var (
 	// Version is the current version of the qasm CLI
-	Version = "0.2.2"
+	Version = "0.2.3"
 
 	// BuildDate is the date when the binary was built
 	BuildDate = "unknown"


### PR DESCRIPTION
This pull request is for the next release as v0.2.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Remove Java setup and parser generation from release workflow by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/51


**Full Changelog**: https://github.com/orangekame3/qasmtools/compare/v0.2.2...v0.2.3