### PR TITLE
Release for v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.12](https://github.com/orangekame3/qasmtools/compare/v0.2.11...v0.2.12) - 2025-07-01
+- Refactor linting code for improved content retrieval by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/75
+
 ## [v0.2.11](https://github.com/orangekame3/qasmtools/compare/v0.2.10...v0.2.11) - 2025-07-01
 - Enhance functionality and performance of QASM Tools Playground by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/73
 

--- a/cmd/qasm/version.go
+++ b/cmd/qasm/version.go
@@ -3,7 +3,7 @@ package main
 // Version information for the QASM CLI tool
 var (
 	// Version is the current version of the qasm CLI
-	Version = "0.2.11"
+	Version = "0.2.12"
 
 	// BuildDate is the date when the binary was built
 	BuildDate = "unknown"


### PR DESCRIPTION
This pull request is for the next release as v0.2.12 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.12 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.11" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Refactor linting code for improved content retrieval by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/75


**Full Changelog**: https://github.com/orangekame3/qasmtools/compare/v0.2.11...v0.2.12