### PR TITLE
Add Parse command to QASM CLI initialization

### DIFF
--- a/cmd/qasm/main.go
+++ b/cmd/qasm/main.go
@@ -27,5 +27,6 @@ func init() {
 		commands.NewFormatCommand(),
 		commands.NewHighlightCommand(),
 		commands.NewLintCommand(),
+		commands.NewParseCommand(),
 	)
 }


### PR DESCRIPTION
Introduce the Parse command during the initialization of the QASM CLI to enhance command functionality.