### PR TITLE
Add commands for formatting, highlighting, linting, and parsing QASM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ vendor/
 vscode-qasm/node_modules/
 CLAUDE.md
 .claude/
-qasm
+

--- a/cmd/qasm/commands/benchmark.go
+++ b/cmd/qasm/commands/benchmark.go
@@ -1,0 +1,385 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/orangekame3/qasmtools/parser"
+	"github.com/spf13/cobra"
+)
+
+// BenchmarkResult represents the results of a single benchmark run
+type BenchmarkResult struct {
+	Filename   string        `json:"filename"`
+	FileSize   int64         `json:"file_size"`
+	Statements int           `json:"statements"`
+	ParseTime  time.Duration `json:"parse_time"`
+	Success    bool          `json:"success"`
+	Error      string        `json:"error,omitempty"`
+	Throughput float64       `json:"throughput"` // bytes/second
+}
+
+// BenchmarkSuite represents a complete benchmark suite
+type BenchmarkSuite struct {
+	Name      string            `json:"name"`
+	Version   string            `json:"version"`
+	Results   []BenchmarkResult `json:"results"`
+	Summary   BenchmarkSummary  `json:"summary"`
+	Timestamp time.Time         `json:"timestamp"`
+}
+
+// BenchmarkSummary provides aggregate statistics
+type BenchmarkSummary struct {
+	TotalFiles      int           `json:"total_files"`
+	SuccessfulFiles int           `json:"successful_files"`
+	FailedFiles     int           `json:"failed_files"`
+	SuccessRate     float64       `json:"success_rate"`
+	TotalTime       time.Duration `json:"total_time"`
+	AverageTime     time.Duration `json:"average_time"`
+	MinTime         time.Duration `json:"min_time"`
+	MaxTime         time.Duration `json:"max_time"`
+	MedianTime      time.Duration `json:"median_time"`
+	StdDeviation    time.Duration `json:"std_deviation"`
+	TotalStatements int           `json:"total_statements"`
+	TotalBytes      int64         `json:"total_bytes"`
+	AvgThroughput   float64       `json:"avg_throughput"`
+}
+
+// NewBenchmarkCommand creates the benchmark command
+func NewBenchmarkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "benchmark [directory]",
+		Short: "Run comprehensive parser benchmarks",
+		Long:  `Run comprehensive parser benchmarks against QASM files to measure performance and compatibility.`,
+		RunE:  runBenchmark,
+	}
+
+	// Add flags
+	cmd.Flags().Int("runs", 10, "Number of parsing runs per file")
+	cmd.Flags().Int("warmup", 3, "Number of warmup runs before benchmarking")
+	cmd.Flags().Bool("detailed", false, "Show detailed results for each file")
+	cmd.Flags().String("output", "text", "Output format (text, json, csv)")
+	cmd.Flags().String("filter", "*.qasm", "File pattern to match")
+	cmd.Flags().Bool("recursive", true, "Search subdirectories recursively")
+	cmd.Flags().Bool("ignore-errors", false, "Continue benchmarking even if some files fail")
+	cmd.Flags().String("suite-name", "qasmtools", "Name of the benchmark suite")
+
+	return cmd
+}
+
+func runBenchmark(cmd *cobra.Command, args []string) error {
+	// Get flags
+	runs, _ := cmd.Flags().GetInt("runs")
+	warmup, _ := cmd.Flags().GetInt("warmup")
+	detailed, _ := cmd.Flags().GetBool("detailed")
+	outputFormat, _ := cmd.Flags().GetString("output")
+	filter, _ := cmd.Flags().GetString("filter")
+	recursive, _ := cmd.Flags().GetBool("recursive")
+	ignoreErrors, _ := cmd.Flags().GetBool("ignore-errors")
+	suiteName, _ := cmd.Flags().GetString("suite-name")
+
+	// Determine directory to benchmark
+	directory := "."
+	if len(args) > 0 {
+		directory = args[0]
+	}
+
+	// Find QASM files
+	files, err := findQASMFiles(directory, filter, recursive)
+	if err != nil {
+		return fmt.Errorf("failed to find QASM files: %w", err)
+	}
+
+	if len(files) == 0 {
+		return fmt.Errorf("no QASM files found in directory: %s", directory)
+	}
+
+	fmt.Printf("🔍 Found %d QASM files to benchmark\n", len(files))
+	fmt.Printf("⚙️  Configuration: %d runs per file, %d warmup runs\n", runs, warmup)
+	fmt.Printf("📊 Starting benchmark suite...\n\n")
+
+	// Create benchmark suite
+	suite := &BenchmarkSuite{
+		Name:      suiteName,
+		Version:   "1.0.0", // TODO: Get from version
+		Results:   make([]BenchmarkResult, 0, len(files)),
+		Timestamp: time.Now(),
+	}
+
+	// Run benchmarks
+	for i, file := range files {
+		fmt.Printf("📄 [%d/%d] %s", i+1, len(files), filepath.Base(file))
+
+		result := benchmarkFile(file, runs, warmup)
+		suite.Results = append(suite.Results, result)
+
+		if result.Success {
+			fmt.Printf(" ✅ %v (%d statements)\n", result.ParseTime, result.Statements)
+		} else {
+			fmt.Printf(" ❌ %s\n", result.Error)
+			if !ignoreErrors {
+				return fmt.Errorf("benchmarking failed for %s: %s", file, result.Error)
+			}
+		}
+	}
+
+	// Calculate summary statistics
+	suite.Summary = calculateSummary(suite.Results)
+
+	// Output results
+	switch outputFormat {
+	case "json":
+		return outputBenchmarkJSON(suite)
+	case "csv":
+		return outputCSV(suite)
+	default:
+		return outputText(suite, detailed)
+	}
+}
+
+func findQASMFiles(directory, pattern string, recursive bool) ([]string, error) {
+	var files []string
+
+	if recursive {
+		err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !d.IsDir() {
+				if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
+					files = append(files, path)
+				}
+			}
+			return nil
+		})
+		return files, err
+	}
+
+	// Non-recursive search
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			if matched, _ := filepath.Match(pattern, entry.Name()); matched {
+				files = append(files, filepath.Join(directory, entry.Name()))
+			}
+		}
+	}
+
+	return files, nil
+}
+
+func benchmarkFile(filename string, runs, warmup int) BenchmarkResult {
+	result := BenchmarkResult{
+		Filename: filename,
+		Success:  false,
+	}
+
+	// Get file size
+	if stat, err := os.Stat(filename); err == nil {
+		result.FileSize = stat.Size()
+	}
+
+	// Read file content
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		result.Error = fmt.Sprintf("Failed to read file: %v", err)
+		return result
+	}
+
+	contentStr := string(content)
+
+	// Warmup runs
+	p := parser.NewParser()
+	for i := 0; i < warmup; i++ {
+		_, _ = p.ParseString(contentStr)
+	}
+
+	// Benchmark runs
+	var durations []time.Duration
+	var program *parser.Program
+	var lastErr error
+
+	for i := 0; i < runs; i++ {
+		p := parser.NewParser()
+		start := time.Now()
+		prog, parseErr := p.ParseString(contentStr)
+		duration := time.Since(start)
+
+		if parseErr != nil {
+			lastErr = parseErr
+			continue
+		}
+
+		durations = append(durations, duration)
+		if i == 0 {
+			program = prog
+		}
+	}
+
+	if len(durations) == 0 {
+		result.Error = fmt.Sprintf("All parsing attempts failed: %v", lastErr)
+		return result
+	}
+
+	// Calculate average time
+	var totalTime time.Duration
+	for _, d := range durations {
+		totalTime += d
+	}
+	avgTime := totalTime / time.Duration(len(durations))
+
+	// Set results
+	result.Success = true
+	result.ParseTime = avgTime
+	result.Throughput = float64(result.FileSize) / avgTime.Seconds()
+
+	if program != nil {
+		result.Statements = len(program.Statements)
+	}
+
+	return result
+}
+
+func calculateSummary(results []BenchmarkResult) BenchmarkSummary {
+	summary := BenchmarkSummary{
+		TotalFiles: len(results),
+		MinTime:    time.Duration(math.MaxInt64),
+		MaxTime:    0,
+	}
+
+	var successfulTimes []time.Duration
+	var totalThroughput float64
+
+	for _, result := range results {
+		summary.TotalBytes += result.FileSize
+		summary.TotalStatements += result.Statements
+
+		if result.Success {
+			summary.SuccessfulFiles++
+			summary.TotalTime += result.ParseTime
+			successfulTimes = append(successfulTimes, result.ParseTime)
+			totalThroughput += result.Throughput
+
+			if result.ParseTime < summary.MinTime {
+				summary.MinTime = result.ParseTime
+			}
+			if result.ParseTime > summary.MaxTime {
+				summary.MaxTime = result.ParseTime
+			}
+		} else {
+			summary.FailedFiles++
+		}
+	}
+
+	if summary.SuccessfulFiles > 0 {
+		summary.SuccessRate = float64(summary.SuccessfulFiles) / float64(summary.TotalFiles) * 100
+		summary.AverageTime = summary.TotalTime / time.Duration(summary.SuccessfulFiles)
+		summary.AvgThroughput = totalThroughput / float64(summary.SuccessfulFiles)
+
+		// Calculate median
+		sort.Slice(successfulTimes, func(i, j int) bool {
+			return successfulTimes[i] < successfulTimes[j]
+		})
+		mid := len(successfulTimes) / 2
+		if len(successfulTimes)%2 == 0 {
+			summary.MedianTime = (successfulTimes[mid-1] + successfulTimes[mid]) / 2
+		} else {
+			summary.MedianTime = successfulTimes[mid]
+		}
+
+		// Calculate standard deviation
+		var variance float64
+		for _, t := range successfulTimes {
+			diff := t.Seconds() - summary.AverageTime.Seconds()
+			variance += diff * diff
+		}
+		variance /= float64(len(successfulTimes))
+		summary.StdDeviation = time.Duration(math.Sqrt(variance) * float64(time.Second))
+	}
+
+	return summary
+}
+
+func outputText(suite *BenchmarkSuite, detailed bool) error {
+	fmt.Printf("\n📊 Benchmark Results Summary\n")
+	fmt.Printf("==========================================\n")
+	fmt.Printf("Suite: %s v%s\n", suite.Name, suite.Version)
+	fmt.Printf("Timestamp: %s\n", suite.Timestamp.Format("2006-01-02 15:04:05"))
+	fmt.Printf("==========================================\n\n")
+
+	s := suite.Summary
+	fmt.Printf("📁 Files: %d total, %d successful, %d failed\n", s.TotalFiles, s.SuccessfulFiles, s.FailedFiles)
+	fmt.Printf("✅ Success Rate: %.1f%%\n", s.SuccessRate)
+	fmt.Printf("📊 Total Bytes: %d\n", s.TotalBytes)
+	fmt.Printf("📝 Total Statements: %d\n", s.TotalStatements)
+	fmt.Printf("\n⏱️  Timing Statistics:\n")
+	fmt.Printf("   Total Time: %v\n", s.TotalTime)
+	fmt.Printf("   Average Time: %v\n", s.AverageTime)
+	fmt.Printf("   Median Time: %v\n", s.MedianTime)
+	fmt.Printf("   Min Time: %v\n", s.MinTime)
+	fmt.Printf("   Max Time: %v\n", s.MaxTime)
+	fmt.Printf("   Std Deviation: %v\n", s.StdDeviation)
+	fmt.Printf("\n🚀 Throughput: %.2f bytes/sec (average)\n", s.AvgThroughput)
+
+	if detailed {
+		fmt.Printf("\n📋 Detailed Results:\n")
+		fmt.Printf("%-30s %10s %8s %12s %12s\n", "File", "Size", "Stmts", "Time", "Throughput")
+		fmt.Printf("%-30s %10s %8s %12s %12s\n", strings.Repeat("-", 30), strings.Repeat("-", 10), strings.Repeat("-", 8), strings.Repeat("-", 12), strings.Repeat("-", 12))
+
+		for _, result := range suite.Results {
+			filename := filepath.Base(result.Filename)
+			if len(filename) > 30 {
+				filename = filename[:27] + "..."
+			}
+
+			if result.Success {
+				fmt.Printf("%-30s %10d %8d %12v %12.0f\n",
+					filename, result.FileSize, result.Statements, result.ParseTime, result.Throughput)
+			} else {
+				fmt.Printf("%-30s %10d %8s %12s %12s\n",
+					filename, result.FileSize, "ERROR", "-", "-")
+			}
+		}
+	}
+
+	return nil
+}
+
+func outputBenchmarkJSON(suite *BenchmarkSuite) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(suite)
+}
+
+func outputCSV(suite *BenchmarkSuite) error {
+	fmt.Printf("filename,file_size,statements,parse_time_ns,success,throughput,error\n")
+	for _, result := range suite.Results {
+		errorStr := ""
+		if !result.Success {
+			errorStr = strings.ReplaceAll(result.Error, "\"", "\"\"")
+		}
+
+		fmt.Printf("%s,%d,%d,%d,%t,%.2f,\"%s\"\n",
+			result.Filename,
+			result.FileSize,
+			result.Statements,
+			result.ParseTime.Nanoseconds(),
+			result.Success,
+			result.Throughput,
+			errorStr,
+		)
+	}
+	return nil
+}

--- a/cmd/qasm/commands/format.go
+++ b/cmd/qasm/commands/format.go
@@ -1,0 +1,173 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/orangekame3/qasmtools/cmd/qasm/config"
+	"github.com/orangekame3/qasmtools/cmd/qasm/ioutils"
+	"github.com/orangekame3/qasmtools/formatter"
+	"github.com/spf13/cobra"
+)
+
+// NewFormatCommand creates the format command
+func NewFormatCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fmt [files...]",
+		Short: "Format QASM files",
+		Long:  `Format one or more QASM files according to the standard style.`,
+		RunE:  runFormat,
+	}
+
+	// Add flags
+	cmd.Flags().BoolP("write", "w", false, "Write result to file instead of stdout")
+	cmd.Flags().BoolP("check", "c", false, "Check if files are formatted")
+	cmd.Flags().Bool("stdin", false, "Read from stdin")
+	cmd.Flags().UintP("indent", "i", 2, "Number of spaces for indentation")
+	cmd.Flags().Bool("newline", true, "Add newline at end of file")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+
+	return cmd
+}
+
+func runFormat(cmd *cobra.Command, args []string) error {
+	stdin, _ := cmd.Flags().GetBool("stdin")
+	if !stdin && len(args) == 0 {
+		// Check if input is being piped
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			config, err := config.GetConfigFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			return RunFormatStdin(cmd, config)
+		}
+		return fmt.Errorf("at least one file is required (or use --stdin flag)")
+	}
+
+	config, err := config.GetConfigFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	if stdin {
+		return RunFormatStdin(cmd, config)
+	}
+
+	return runFormatWithConfig(cmd, args, config)
+}
+
+func RunFormatStdin(cmd *cobra.Command, config *formatter.Config) error {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read from stdin: %w", err)
+	}
+
+	formatted, err := formatter.FormatQASMWithConfig(string(input), config)
+	if err != nil {
+		return fmt.Errorf("failed to format QASM: %w", err)
+	}
+
+	if config.Check {
+		if string(input) != formatted {
+			fmt.Fprintln(os.Stderr, "stdin: not formatted")
+			os.Exit(1)
+		}
+		return nil
+	}
+
+	fmt.Print(formatted)
+	return nil
+}
+
+func runFormatWithConfig(cmd *cobra.Command, args []string, config *formatter.Config) error {
+	hasError := false
+	hasChanges := false
+
+	for _, filename := range args {
+		changed, err := FormatFileWithConfig(filename, config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting %s: %v\n", filename, err)
+			hasError = true
+			continue
+		}
+		if changed {
+			hasChanges = true
+		}
+	}
+
+	if hasError {
+		return fmt.Errorf("formatting failed for one or more files")
+	}
+
+	if config.Check && hasChanges {
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+func FormatFileWithConfig(filename string, config *formatter.Config) (bool, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return false, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	formatted, err := formatter.FormatQASMWithConfig(string(content), config)
+	if err != nil {
+		return false, fmt.Errorf("failed to format QASM: %w", err)
+	}
+
+	original := string(content)
+	changed := original != formatted
+
+	if config.Check {
+		if changed {
+			fmt.Fprintf(os.Stderr, "%s: not formatted\n", filename)
+		} else if config.Verbose {
+			fmt.Fprintf(os.Stderr, "%s: already formatted\n", filename)
+		}
+		return changed, nil
+	}
+
+	if config.Write {
+		if changed {
+			err = os.WriteFile(filename, []byte(formatted), 0644)
+			if err != nil {
+				return false, fmt.Errorf("failed to write file: %w", err)
+			}
+			if config.Verbose {
+				fmt.Fprintf(os.Stderr, "Formatted %s\n", filename)
+			}
+		} else if config.Verbose {
+			fmt.Fprintf(os.Stderr, "%s: no changes\n", filename)
+		}
+	} else {
+		if changed && config.Verbose {
+			err = ioutils.ShowDiff(filename, original, formatted)
+			if err != nil {
+				return false, err
+			}
+		}
+		fmt.Print(formatted)
+	}
+
+	return changed, nil
+}
+
+// CheckFileWithConfig checks if a file is properly formatted
+func CheckFileWithConfig(filename string, config *formatter.Config) (bool, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return false, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	formatted, err := formatter.FormatQASMWithConfig(string(content), config)
+	if err != nil {
+		return false, fmt.Errorf("failed to format QASM: %w", err)
+	}
+
+	// Returns true if already formatted (no changes needed)
+	return string(content) == formatted, nil
+}

--- a/cmd/qasm/commands/highlight.go
+++ b/cmd/qasm/commands/highlight.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/orangekame3/qasmtools/highlight"
+	"github.com/spf13/cobra"
+)
+
+// NewHighlightCommand creates the highlight command
+func NewHighlightCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "highlight [file]",
+		Short: "Highlight QASM files with syntax coloring",
+		Long:  `Apply syntax highlighting to QASM files for better readability.`,
+		RunE:  runHighlight,
+	}
+
+	// Add flags
+	cmd.Flags().Bool("stdin", false, "Read from stdin")
+	cmd.Flags().Bool("semantic", false, "Use semantic highlighting (slower but more accurate)")
+
+	return cmd
+}
+
+func runHighlight(cmd *cobra.Command, args []string) error {
+	stdin, _ := cmd.Flags().GetBool("stdin")
+	semantic, _ := cmd.Flags().GetBool("semantic")
+
+	if !stdin && len(args) == 0 {
+		// Check if input is being piped
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			return runHighlightStdin(semantic)
+		}
+		return fmt.Errorf("at least one file is required (or use --stdin flag)")
+	}
+
+	if stdin {
+		return runHighlightStdin(semantic)
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("exactly one file is required")
+	}
+
+	return runHighlightFile(args[0], semantic)
+}
+
+func runHighlightStdin(semantic bool) error {
+	content, err := os.ReadFile("/dev/stdin")
+	if err != nil {
+		return fmt.Errorf("failed to read from stdin: %w", err)
+	}
+
+	var highlighted string
+	if semantic {
+		highlighter := highlight.NewASTHighlighter()
+		highlighted, err = highlighter.HighlightWithAST(string(content))
+	} else {
+		highlighter := highlight.New()
+		highlighted, err = highlighter.Highlight(string(content))
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to highlight QASM: %w", err)
+	}
+
+	fmt.Print(highlighted)
+	return nil
+}
+
+func runHighlightFile(filename string, semantic bool) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", filename, err)
+	}
+
+	var highlighted string
+	if semantic {
+		highlighter := highlight.NewASTHighlighter()
+		highlighted, err = highlighter.HighlightWithAST(string(content))
+	} else {
+		highlighter := highlight.New()
+		highlighted, err = highlighter.Highlight(string(content))
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to highlight QASM: %w", err)
+	}
+
+	fmt.Print(highlighted)
+	return nil
+}

--- a/cmd/qasm/commands/lint.go
+++ b/cmd/qasm/commands/lint.go
@@ -1,0 +1,281 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/orangekame3/qasmtools/lint"
+	"github.com/spf13/cobra"
+)
+
+// NewLintCommand creates the lint command
+func NewLintCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lint [files...]",
+		Short: "Lint QASM files for errors and style issues",
+		Long:  `Analyze QASM files for potential errors, style violations, and best practice issues.`,
+		RunE:  runLint,
+	}
+
+	// Add flags
+	cmd.Flags().String("rules", "", "Rules directory")
+	cmd.Flags().StringSlice("disable", []string{}, "Disable specific rules (comma-separated)")
+	cmd.Flags().StringSlice("enable-only", []string{}, "Enable only specific rules (comma-separated)")
+	cmd.Flags().String("format", "text", "Output format (text, json)")
+	cmd.Flags().BoolP("quiet", "q", false, "Only show errors, not warnings")
+	cmd.Flags().Bool("no-color", false, "Disable colored output")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+	cmd.Flags().Bool("use-ast", true, "Use AST-based analysis (faster and more accurate)")
+	cmd.Flags().Bool("parallel", true, "Enable parallel processing for multiple files")
+	cmd.Flags().Int("workers", 4, "Number of worker threads for parallel processing")
+	cmd.Flags().Bool("performance", false, "Show performance statistics")
+	cmd.Flags().Bool("stdin", false, "Read from stdin")
+
+	return cmd
+}
+
+func runLint(cmd *cobra.Command, args []string) error {
+	stdin, _ := cmd.Flags().GetBool("stdin")
+
+	// Check if we should read from stdin
+	if stdin {
+		return runLintStdin(cmd)
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("at least one file is required")
+	}
+
+	rulesDir, _ := cmd.Flags().GetString("rules")
+	disabled, _ := cmd.Flags().GetStringSlice("disable")
+	enabledOnly, _ := cmd.Flags().GetStringSlice("enable-only")
+	format, _ := cmd.Flags().GetString("format")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	useAST, _ := cmd.Flags().GetBool("use-ast")
+	parallel, _ := cmd.Flags().GetBool("parallel")
+	workers, _ := cmd.Flags().GetInt("workers")
+	showPerf, _ := cmd.Flags().GetBool("performance")
+
+	// Create optimized linter based on configuration
+	var violations []*lint.Violation
+	var err error
+
+	if parallel && len(args) > 1 {
+		// Use batch linter for multiple files
+		batchLinter := lint.NewBatchLinter(rulesDir, workers)
+		err = batchLinter.LoadRules()
+		if err != nil {
+			return fmt.Errorf("failed to load rules: %w", err)
+		}
+		violations, err = batchLinter.LintFilesParallel(args)
+		if showPerf {
+			printPerformanceStats(batchLinter.GetStats())
+		}
+	} else {
+		// Use standard linter
+		linter := lint.NewLinterWithAST(rulesDir, useAST)
+		err = linter.LoadRules()
+		if err != nil {
+			return fmt.Errorf("failed to load rules: %w", err)
+		}
+		violations, err = linter.LintFiles(args)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to lint files: %w", err)
+	}
+
+	// Filter violations based on flags
+	filteredViolations := filterViolations(violations, disabled, enabledOnly, quiet)
+
+	// Output results
+	switch format {
+	case "json":
+		return outputJSON(filteredViolations)
+	default:
+		return outputTextWithColor(filteredViolations, !noColor)
+	}
+}
+
+func filterViolations(violations []*lint.Violation, disabled []string, enabledOnly []string, quiet bool) []*lint.Violation {
+	var filtered []*lint.Violation
+
+	disabledMap := make(map[string]bool)
+	for _, rule := range disabled {
+		disabledMap[rule] = true
+	}
+
+	enabledMap := make(map[string]bool)
+	for _, rule := range enabledOnly {
+		enabledMap[rule] = true
+	}
+
+	for _, violation := range violations {
+		// Skip if rule is disabled
+		if disabledMap[violation.Rule.ID] {
+			continue
+		}
+
+		// Skip if only specific rules are enabled and this isn't one of them
+		if len(enabledOnly) > 0 && !enabledMap[violation.Rule.ID] {
+			continue
+		}
+
+		// Skip warnings if quiet mode is enabled
+		if quiet && violation.Severity != lint.SeverityError {
+			continue
+		}
+
+		filtered = append(filtered, violation)
+	}
+
+	return filtered
+}
+
+// outputJSON outputs violations in JSON format
+func outputJSON(violations []*lint.Violation) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(violations)
+}
+
+// outputTextWithColor outputs violations with colored text
+func outputTextWithColor(violations []*lint.Violation, useColor bool) error {
+	if len(violations) == 0 {
+		if useColor {
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+			fmt.Println(style.Render("✅ No issues found"))
+		} else {
+			fmt.Println("✅ No issues found")
+		}
+		return nil
+	}
+
+	// Define styles for colored output
+	var fileStyle, errorStyle, warningStyle, infoStyle, ruleStyle, urlStyle lipgloss.Style
+	if useColor {
+		fileStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)    // Blue
+		errorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Bold(true)    // Red
+		warningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true) // Yellow
+		infoStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)    // Cyan
+		ruleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true)    // Magenta
+		urlStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)    // Gray
+	} else {
+		fileStyle = lipgloss.NewStyle()
+		errorStyle = lipgloss.NewStyle()
+		warningStyle = lipgloss.NewStyle()
+		infoStyle = lipgloss.NewStyle()
+		ruleStyle = lipgloss.NewStyle()
+		urlStyle = lipgloss.NewStyle()
+	}
+
+	for _, violation := range violations {
+		// Format colored output
+		filePart := fileStyle.Render(fmt.Sprintf("%s:%d:%d:", violation.File, violation.Line, violation.Column))
+
+		var severityPart string
+		switch violation.Severity {
+		case lint.SeverityError:
+			severityPart = errorStyle.Render(string(violation.Severity))
+		case lint.SeverityWarning:
+			severityPart = warningStyle.Render(string(violation.Severity))
+		case lint.SeverityInfo:
+			severityPart = infoStyle.Render(string(violation.Severity))
+		}
+
+		rulePart := ruleStyle.Render(fmt.Sprintf("[%s]", violation.Rule.ID))
+
+		var result string
+		if violation.Rule.DocumentationURL != "" {
+			urlPart := urlStyle.Render(fmt.Sprintf("(%s)", violation.Rule.DocumentationURL))
+			result = fmt.Sprintf("%s %s %s %s %s", filePart, severityPart, rulePart, violation.Message, urlPart)
+		} else {
+			result = fmt.Sprintf("%s %s %s %s", filePart, severityPart, rulePart, violation.Message)
+		}
+
+		fmt.Println(result)
+	}
+
+	// Summary
+	errorCount := 0
+	warningCount := 0
+	infoCount := 0
+
+	for _, violation := range violations {
+		switch violation.Severity {
+		case lint.SeverityError:
+			errorCount++
+		case lint.SeverityWarning:
+			warningCount++
+		case lint.SeverityInfo:
+			infoCount++
+		}
+	}
+
+	fmt.Printf("\n📊 Found %d issues: %d errors, %d warnings, %d info\n",
+		len(violations), errorCount, warningCount, infoCount)
+
+	return nil
+}
+
+// printPerformanceStats outputs performance statistics
+func printPerformanceStats(stats lint.PerformanceStats) {
+	fmt.Printf("\n⚡ Performance Stats:\n")
+	fmt.Printf("   Files processed: %d\n", stats.TotalFiles)
+	fmt.Printf("   Total time: %v\n", stats.TotalTime)
+	fmt.Printf("   Parse time: %v\n", stats.ParseTime)
+	fmt.Printf("   Analysis time: %v\n", stats.AnalysisTime)
+	fmt.Printf("   AST rules used: %d\n", stats.ASTRulesUsed)
+	fmt.Printf("   Text rules used: %d\n", stats.TextRulesUsed)
+	if stats.TotalFiles > 0 {
+		avgTime := stats.TotalTime / time.Duration(stats.TotalFiles)
+		fmt.Printf("   Average time per file: %v\n", avgTime)
+	}
+}
+
+// runLintStdin handles linting from stdin
+func runLintStdin(cmd *cobra.Command) error {
+	// Read from stdin
+	content, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read from stdin: %w", err)
+	}
+
+	// Get flags
+	rulesDir, _ := cmd.Flags().GetString("rules")
+	disabled, _ := cmd.Flags().GetStringSlice("disable")
+	enabledOnly, _ := cmd.Flags().GetStringSlice("enable-only")
+	format, _ := cmd.Flags().GetString("format")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	useAST, _ := cmd.Flags().GetBool("use-ast")
+
+	// Create linter
+	linter := lint.NewLinterWithAST(rulesDir, useAST)
+	err = linter.LoadRules()
+	if err != nil {
+		return fmt.Errorf("failed to load rules: %w", err)
+	}
+
+	// Lint content
+	violations, err := linter.LintContent(string(content), "<stdin>")
+	if err != nil {
+		return fmt.Errorf("failed to lint content: %w", err)
+	}
+
+	// Filter violations
+	filteredViolations := filterViolations(violations, disabled, enabledOnly, quiet)
+
+	// Output results
+	switch format {
+	case "json":
+		return outputJSON(filteredViolations)
+	default:
+		return outputTextWithColor(filteredViolations, !noColor)
+	}
+}

--- a/cmd/qasm/commands/parse.go
+++ b/cmd/qasm/commands/parse.go
@@ -1,0 +1,318 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"time"
+
+	"github.com/mattn/go-isatty"
+	"github.com/orangekame3/qasmtools/parser"
+	"github.com/spf13/cobra"
+)
+
+// NewParseCommand creates the parse command
+func NewParseCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "parse [files...]",
+		Short: "Parse QASM files and output AST",
+		Long:  `Parse QASM files and output the Abstract Syntax Tree (AST) in various formats.`,
+		RunE:  runParse,
+	}
+
+	// Add flags
+	cmd.Flags().Bool("stdin", false, "Read from stdin")
+	cmd.Flags().String("format", "json", "Output format (json, tree, summary)")
+	cmd.Flags().Bool("pretty", true, "Pretty print JSON output")
+	cmd.Flags().Bool("include-positions", false, "Include line and column positions in output")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output with parsing details")
+	cmd.Flags().Bool("benchmark", false, "Show parsing performance metrics")
+	cmd.Flags().Int("repeat", 1, "Number of times to repeat parsing (for benchmarking)")
+
+	return cmd
+}
+
+func runParse(cmd *cobra.Command, args []string) error {
+	stdin, _ := cmd.Flags().GetBool("stdin")
+	if !stdin && len(args) == 0 {
+		// Check if input is being piped
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			return runParseStdin(cmd)
+		}
+		return fmt.Errorf("at least one file is required (or use --stdin flag)")
+	}
+
+	if stdin {
+		return runParseStdin(cmd)
+	}
+
+	return runParseFiles(cmd, args)
+}
+
+func runParseStdin(cmd *cobra.Command) error {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read from stdin: %w", err)
+	}
+
+	return parseAndOutput(cmd, string(input), "<stdin>")
+}
+
+func runParseFiles(cmd *cobra.Command, files []string) error {
+	for _, filename := range files {
+		content, err := os.ReadFile(filename)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", filename, err)
+		}
+
+		if len(files) > 1 {
+			fmt.Printf("=== %s ===\n", filename)
+		}
+
+		err = parseAndOutput(cmd, string(content), filename)
+		if err != nil {
+			return err
+		}
+
+		if len(files) > 1 {
+			fmt.Println()
+		}
+	}
+
+	return nil
+}
+
+func parseAndOutput(cmd *cobra.Command, content, filename string) error {
+	format, _ := cmd.Flags().GetString("format")
+	pretty, _ := cmd.Flags().GetBool("pretty")
+	includePositions, _ := cmd.Flags().GetBool("include-positions")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	benchmark, _ := cmd.Flags().GetBool("benchmark")
+	repeat, _ := cmd.Flags().GetInt("repeat")
+
+	// Performance measurement
+	var program *parser.Program
+	var err error
+	var totalDuration time.Duration
+	var minDuration, maxDuration time.Duration
+	var durations []time.Duration
+
+	if benchmark || repeat > 1 {
+		// Multiple parsing runs for benchmarking
+		for i := 0; i < repeat; i++ {
+			p := parser.NewParser()
+			start := time.Now()
+			prog, parseErr := p.ParseString(content)
+			duration := time.Since(start)
+
+			if parseErr != nil {
+				return fmt.Errorf("failed to parse QASM (run %d): %w", i+1, parseErr)
+			}
+
+			if i == 0 {
+				program = prog
+				err = parseErr
+				minDuration = duration
+				maxDuration = duration
+			} else {
+				if duration < minDuration {
+					minDuration = duration
+				}
+				if duration > maxDuration {
+					maxDuration = duration
+				}
+			}
+
+			totalDuration += duration
+			durations = append(durations, duration)
+		}
+
+		// Show performance stats
+		avgDuration := totalDuration / time.Duration(repeat)
+
+		fmt.Fprintf(os.Stderr, "\n⚡ Parse Performance Results for %s:\n", filename)
+		fmt.Fprintf(os.Stderr, "   File size: %d bytes\n", len(content))
+		if program != nil {
+			fmt.Fprintf(os.Stderr, "   Statements: %d\n", len(program.Statements))
+		}
+		fmt.Fprintf(os.Stderr, "   Runs: %d\n", repeat)
+		fmt.Fprintf(os.Stderr, "   Total time: %v\n", totalDuration)
+		fmt.Fprintf(os.Stderr, "   Average time: %v\n", avgDuration)
+		fmt.Fprintf(os.Stderr, "   Min time: %v\n", minDuration)
+		fmt.Fprintf(os.Stderr, "   Max time: %v\n", maxDuration)
+
+		// Calculate throughput
+		throughput := float64(len(content)) / avgDuration.Seconds()
+		fmt.Fprintf(os.Stderr, "   Throughput: %.2f bytes/sec\n", throughput)
+
+		if repeat > 1 {
+			// Calculate standard deviation
+			var variance float64
+			for _, d := range durations {
+				diff := d.Seconds() - avgDuration.Seconds()
+				variance += diff * diff
+			}
+			variance /= float64(repeat)
+			stdDev := time.Duration(math.Sqrt(variance) * float64(time.Second))
+			fmt.Fprintf(os.Stderr, "   Std deviation: %v\n", stdDev)
+		}
+		fmt.Fprintf(os.Stderr, "\n")
+	} else {
+		// Single parse
+		p := parser.NewParser()
+		start := time.Now()
+		program, err = p.ParseString(content)
+		duration := time.Since(start)
+
+		if err != nil {
+			return fmt.Errorf("failed to parse QASM: %w", err)
+		}
+
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Parsing completed successfully for %s in %v\n", filename, duration)
+			if program != nil && len(program.Statements) > 0 {
+				fmt.Fprintf(os.Stderr, "Found %d statements\n", len(program.Statements))
+			}
+		}
+	}
+
+	switch format {
+	case "json":
+		return outputJSONForParse(program, pretty, includePositions)
+	case "tree":
+		return outputTree(program, includePositions)
+	case "summary":
+		return outputSummary(program, filename)
+	default:
+		return fmt.Errorf("unsupported format: %s (supported: json, tree, summary)", format)
+	}
+}
+
+func outputJSONForParse(program *parser.Program, pretty, includePositions bool) error {
+	encoder := json.NewEncoder(os.Stdout)
+	if pretty {
+		encoder.SetIndent("", "  ")
+	}
+
+	// If includePositions is false, we might want to create a simplified version
+	// For now, we'll output the full program structure
+	return encoder.Encode(program)
+}
+
+func outputTree(program *parser.Program, includePositions bool) error {
+	if program == nil {
+		fmt.Println("(empty program)")
+		return nil
+	}
+
+	fmt.Printf("Program\n")
+	if program.Version != nil {
+		if includePositions {
+			fmt.Printf("├── Version: %s (line: %d, col: %d)\n",
+				program.Version.Number, program.Version.Position.Line, program.Version.Position.Column)
+		} else {
+			fmt.Printf("├── Version: %s\n", program.Version.Number)
+		}
+	}
+
+	fmt.Printf("└── Statements (%d)\n", len(program.Statements))
+	for i, stmt := range program.Statements {
+		isLast := i == len(program.Statements)-1
+		prefix := "    ├── "
+		if isLast {
+			prefix = "    └── "
+		}
+
+		stmtType := fmt.Sprintf("%T", stmt)
+		if includePositions {
+			fmt.Printf("%s%s (line: %d, col: %d)\n",
+				prefix, stmtType, stmt.Pos().Line, stmt.Pos().Column)
+		} else {
+			fmt.Printf("%s%s\n", prefix, stmtType)
+		}
+
+		// Add more detailed output for specific statement types
+		switch s := stmt.(type) {
+		case *parser.QuantumDeclaration:
+			subPrefix := "        "
+			if isLast {
+				subPrefix = "        "
+			}
+			fmt.Printf("%s├── Type: %s\n", subPrefix, s.Type)
+			fmt.Printf("%s├── Identifier: %s\n", subPrefix, s.Identifier)
+			if s.Size != nil {
+				fmt.Printf("%s└── Size: %v\n", subPrefix, s.Size)
+			} else {
+				fmt.Printf("%s└── Size: (single)\n", subPrefix)
+			}
+		case *parser.ClassicalDeclaration:
+			subPrefix := "        "
+			if isLast {
+				subPrefix = "        "
+			}
+			fmt.Printf("%s├── Type: %s\n", subPrefix, s.Type)
+			fmt.Printf("%s└── Identifier: %s\n", subPrefix, s.Identifier)
+		case *parser.GateCall:
+			subPrefix := "        "
+			if isLast {
+				subPrefix = "        "
+			}
+			fmt.Printf("%s├── Gate: %s\n", subPrefix, s.Name)
+			fmt.Printf("%s└── Qubits: %d\n", subPrefix, len(s.Qubits))
+		case *parser.Measurement:
+			subPrefix := "        "
+			if isLast {
+				subPrefix = "        "
+			}
+			fmt.Printf("%s├── Qubit: %v\n", subPrefix, s.Qubit)
+			fmt.Printf("%s└── Target: %v\n", subPrefix, s.Target)
+		}
+	}
+
+	return nil
+}
+
+func outputSummary(program *parser.Program, filename string) error {
+	if program == nil {
+		fmt.Printf("File: %s - No valid program found\n", filename)
+		return nil
+	}
+
+	fmt.Printf("=== QASM Parse Summary ===\n")
+	fmt.Printf("File: %s\n", filename)
+
+	if program.Version != nil {
+		fmt.Printf("Version: %s\n", program.Version.Number)
+	}
+
+	fmt.Printf("Total Statements: %d\n", len(program.Statements))
+
+	// Count different statement types
+	counts := make(map[string]int)
+	for _, stmt := range program.Statements {
+		// Simplify type names
+		switch stmt.(type) {
+		case *parser.QuantumDeclaration:
+			counts["Qubit Declarations"]++
+		case *parser.ClassicalDeclaration:
+			counts["Classical Declarations"]++
+		case *parser.GateCall:
+			counts["Gate Calls"]++
+		case *parser.Measurement:
+			counts["Measurements"]++
+		case *parser.Include:
+			counts["Include Statements"]++
+		default:
+			counts["Other"]++
+		}
+	}
+
+	fmt.Println("\nStatement Breakdown:")
+	for stmtType, count := range counts {
+		fmt.Printf("  %s: %d\n", stmtType, count)
+	}
+
+	return nil
+}

--- a/cmd/qasm/config/config.go
+++ b/cmd/qasm/config/config.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"github.com/orangekame3/qasmtools/formatter"
+	"github.com/spf13/cobra"
+)
+
+// GetConfigFromFlags extracts formatter configuration from command flags
+func GetConfigFromFlags(cmd *cobra.Command) (*formatter.Config, error) {
+	write, err := cmd.Flags().GetBool("write")
+	if err != nil {
+		return nil, err
+	}
+
+	check, err := cmd.Flags().GetBool("check")
+	if err != nil {
+		return nil, err
+	}
+
+	indent, err := cmd.Flags().GetUint("indent")
+	if err != nil {
+		return nil, err
+	}
+
+	newline, err := cmd.Flags().GetBool("newline")
+	if err != nil {
+		return nil, err
+	}
+
+	verbose, err := cmd.Flags().GetBool("verbose")
+	if err != nil {
+		return nil, err
+	}
+
+	return &formatter.Config{
+		Write:   write,
+		Check:   check,
+		Indent:  indent,
+		Newline: newline,
+		Verbose: verbose,
+	}, nil
+}
+
+// AddCommonFormatFlags adds common formatting flags to a command
+func AddCommonFormatFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("write", "w", false, "Write result to file instead of stdout")
+	cmd.Flags().BoolP("check", "c", false, "Check if files are formatted")
+	cmd.Flags().UintP("indent", "i", 2, "Number of spaces for indentation")
+	cmd.Flags().Bool("newline", true, "Add newline at end of file")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+}
+
+// AddCommonLintFlags adds common linting flags to a command
+func AddCommonLintFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("disable", []string{}, "Disable specific rules (comma-separated)")
+	cmd.Flags().StringSlice("enable-only", []string{}, "Enable only specific rules (comma-separated)")
+	cmd.Flags().BoolP("quiet", "q", false, "Only show errors, not warnings")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+}
+
+// AddCommonIOFlags adds common I/O flags to a command
+func AddCommonIOFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("stdin", false, "Read from stdin")
+}

--- a/cmd/qasm/ioutils/ioutils.go
+++ b/cmd/qasm/ioutils/ioutils.go
@@ -1,0 +1,114 @@
+package ioutils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss/v2"
+)
+
+// ShowDiff displays a formatted diff between original and formatted content
+func ShowDiff(filename, original, formatted string) error {
+	// Simple diff implementation
+	originalLines := strings.Split(original, "\n")
+	formattedLines := strings.Split(formatted, "\n")
+
+	fmt.Fprintf(os.Stderr, "--- %s (original)\n", filename)
+	fmt.Fprintf(os.Stderr, "+++ %s (formatted)\n", filename)
+
+	// Find differences line by line
+	maxLines := len(originalLines)
+	if len(formattedLines) > maxLines {
+		maxLines = len(formattedLines)
+	}
+
+	for i := 0; i < maxLines; i++ {
+		var origLine, formLine string
+		if i < len(originalLines) {
+			origLine = originalLines[i]
+		}
+		if i < len(formattedLines) {
+			formLine = formattedLines[i]
+		}
+
+		if origLine != formLine {
+			if origLine != "" {
+				fmt.Fprintf(os.Stderr, "-%s\n", origLine)
+			}
+			if formLine != "" {
+				fmt.Fprintf(os.Stderr, "+%s\n", formLine)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ReadFileOrStdin reads content from a file or stdin
+func ReadFileOrStdin(filename string) ([]byte, error) {
+	if filename == "" || filename == "-" {
+		return os.ReadFile("/dev/stdin")
+	}
+	return os.ReadFile(filename)
+}
+
+// WriteFileOrStdout writes content to a file or stdout
+func WriteFileOrStdout(filename, content string) error {
+	if filename == "" || filename == "-" {
+		fmt.Print(content)
+		return nil
+	}
+	return os.WriteFile(filename, []byte(content), 0644)
+}
+
+// PrintSuccess prints a success message with styling
+func PrintSuccess(message string) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+	fmt.Fprintln(os.Stderr, style.Render("✅ "+message))
+}
+
+// PrintError prints an error message with styling
+func PrintError(message string) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Bold(true)
+	fmt.Fprintln(os.Stderr, style.Render("❌ "+message))
+}
+
+// PrintWarning prints a warning message with styling
+func PrintWarning(message string) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true)
+	fmt.Fprintln(os.Stderr, style.Render("⚠️  "+message))
+}
+
+// PrintInfo prints an info message with styling
+func PrintInfo(message string) {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
+	fmt.Fprintln(os.Stderr, style.Render("ℹ️  "+message))
+}
+
+// IsStdinPiped checks if stdin is being piped to
+func IsStdinPiped() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+// FileExists checks if a file exists
+func FileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+// EnsureFileExists ensures a file exists, creating it if necessary
+func EnsureFileExists(filename string) error {
+	if !FileExists(filename) {
+		file, err := os.Create(filename)
+		if err != nil {
+			return fmt.Errorf("failed to create file %s: %w", filename, err)
+		}
+		defer file.Close()
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.24.4
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/charmbracelet/fang v0.2.0
+	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
+	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.9.1
 	github.com/tliron/commonlog v0.2.18
 	github.com/tliron/glsp v0.2.2
@@ -14,7 +16,6 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.0 // indirect
-	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
@@ -23,7 +24,6 @@ require (
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/mango v0.1.0 // indirect


### PR DESCRIPTION
Introduce commands to format, highlight, lint, and parse QASM files, enhancing usability and error checking. Implement a configuration package for managing command flags and settings. Add utility functions for improved I/O operations.