### PR TITLE
Release for v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.15](https://github.com/orangekame3/qasmtools/compare/v0.2.14...v0.2.15) - 2025-07-09
+- Add commands for formatting, highlighting, linting, and parsing QASM files by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/95
+
 ## [v0.2.14](https://github.com/orangekame3/qasmtools/compare/v0.2.13...v0.2.14) - 2025-07-09
 - Fix lint issues in codebase by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/79
 - Enhance WASM integration with improved linting and error handling by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/81

--- a/cmd/qasm/version.go
+++ b/cmd/qasm/version.go
@@ -8,7 +8,7 @@ import (
 // Version information for the QASM CLI tool
 var (
 	// Version is the current version of the qasm CLI
-	Version = "0.2.14"
+	Version = "0.2.15"
 
 	// BuildDate is the date when the binary was built
 	BuildDate = "unknown"


### PR DESCRIPTION
This pull request is for the next release as v0.2.15 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.15 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.14" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Add commands for formatting, highlighting, linting, and parsing QASM files by @orangekame3 in https://github.com/orangekame3/qasmtools/pull/95


**Full Changelog**: https://github.com/orangekame3/qasmtools/compare/v0.2.14...v0.2.15