### PR TITLE
Clarify QASM command short description

### DIFF
--- a/cmd/qasm/main.go
+++ b/cmd/qasm/main.go
@@ -25,7 +25,7 @@ func main() {
 
 var rootCmd = &cobra.Command{
 	Use:   "qasm",
-	Short: "QASM tools",
+	Short: "QASM CLI tools",
 	Long:  `A collection of tools for working with QASM files.`,
 }
 


### PR DESCRIPTION
Update the short description of the QASM command to specify that it refers to CLI tools.